### PR TITLE
Custom domain (tahabouhsine.com) + recover Flax 0.12 runtime fixes

### DIFF
--- a/examples/advanced/bert_fineweb.py
+++ b/examples/advanced/bert_fineweb.py
@@ -160,10 +160,10 @@ class BERTModel(nnx.Module):
         self.embeddings = BERTEmbedding(vocab_size, max_len, d_model, dropout, rngs)
         
         # Transformer layers
-        self.layers = [
+        self.layers = nnx.List([
             BERTLayer(d_model, num_heads, d_ff, dropout, rngs)
             for _ in range(num_layers)
-        ]
+        ])
         
         # MLM head
         self.mlm_dense = nnx.Linear(d_model, d_model, rngs=rngs)

--- a/examples/advanced/gpt_training.py
+++ b/examples/advanced/gpt_training.py
@@ -139,10 +139,10 @@ class GPTModel(nnx.Module):
         self.position_embedding = nnx.Embed(max_len, d_model, rngs=rngs)
         
         # Transformer blocks
-        self.blocks = [
+        self.blocks = nnx.List([
             GPTBlock(d_model, num_heads, d_ff, dropout, max_len, rngs)
             for _ in range(num_layers)
-        ]
+        ])
         
         # Final layer norm
         self.ln_f = nnx.LayerNorm(d_model, rngs=rngs)

--- a/examples/distributed/fsdp_sharding.py
+++ b/examples/distributed/fsdp_sharding.py
@@ -54,10 +54,12 @@ class LargeTransformer(nnx.Module):
         # Large embedding layer (often a memory bottleneck)
         self.embedding = nnx.Embed(vocab_size, d_model, rngs=rngs)
         
-        # Multiple transformer layers
-        self.layers = []
+        # Multiple transformer layers. Wrap each layer's sublayers in nnx.Dict
+        # and the stack in nnx.List so they register as pytree children
+        # (required since Flax 0.12).
+        layers = []
         for _ in range(num_layers):
-            layer = {
+            layer = nnx.Dict({
                 'attn_q': nnx.Linear(d_model, d_model, rngs=rngs),
                 'attn_k': nnx.Linear(d_model, d_model, rngs=rngs),
                 'attn_v': nnx.Linear(d_model, d_model, rngs=rngs),
@@ -66,8 +68,9 @@ class LargeTransformer(nnx.Module):
                 'ff2': nnx.Linear(d_ff, d_model, rngs=rngs),
                 'ln1': nnx.LayerNorm(d_model, rngs=rngs),
                 'ln2': nnx.LayerNorm(d_model, rngs=rngs),
-            }
-            self.layers.append(layer)
+            })
+            layers.append(layer)
+        self.layers = nnx.List(layers)
         
         # Output layers
         self.ln_final = nnx.LayerNorm(d_model, rngs=rngs)

--- a/examples/integrations/resnet_streaming.py
+++ b/examples/integrations/resnet_streaming.py
@@ -20,6 +20,8 @@ from pathlib import Path
 # Add parent directory to path for shared imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from shared.models import ResNetBlock
+
 try:
     from datasets import load_dataset
     import datasets
@@ -35,52 +37,9 @@ except ImportError:
 # 1. RESNET BUILDING BLOCKS
 # ============================================================================
 
-class ResNetBlock(nnx.Module):
-    """Basic ResNet block with skip connection."""
-    
-    def __init__(self, channels: int, stride: int = 1, rngs: nnx.Rngs = None):
-        self.conv1 = nnx.Conv(
-            channels, channels, kernel_size=(3, 3),
-            strides=(stride, stride), padding='SAME', rngs=rngs
-        )
-        self.bn1 = nnx.BatchNorm(channels, rngs=rngs)
-        
-        self.conv2 = nnx.Conv(
-            channels, channels, kernel_size=(3, 3),
-            strides=(1, 1), padding='SAME', rngs=rngs
-        )
-        self.bn2 = nnx.BatchNorm(channels, rngs=rngs)
-        
-        # Skip connection (if stride != 1, downsample)
-        self.downsample = None
-        if stride != 1:
-            self.downsample = nnx.Conv(
-                channels, channels, kernel_size=(1, 1),
-                strides=(stride, stride), rngs=rngs
-            )
-            self.bn_downsample = nnx.BatchNorm(channels, rngs=rngs)
-    
-    def __call__(self, x, train: bool = False):
-        identity = x
-        
-        # First conv block
-        out = self.conv1(x)
-        out = self.bn1(out, use_running_average=not train)
-        out = nnx.relu(out)
-        
-        # Second conv block
-        out = self.conv2(out)
-        out = self.bn2(out, use_running_average=not train)
-        
-        # Skip connection
-        if self.downsample is not None:
-            identity = self.downsample(x)
-            identity = self.bn_downsample(identity, use_running_average=not train)
-        
-        out = out + identity
-        out = nnx.relu(out)
-        
-        return out
+# ResNetBlock is imported from shared/models.py. Its signature is
+# ResNetBlock(in_channels, out_channels, stride, rngs); it adds a 1x1
+# projection shortcut automatically when the channel count or stride changes.
 
 
 class ResNet(nnx.Module):
@@ -95,13 +54,19 @@ class ResNet(nnx.Module):
         )
         self.bn1 = nnx.BatchNorm(channels[0], rngs=rngs)
         
-        # ResNet layers
-        self.layers = []
+        # ResNet layers. Track the running channel count so each block knows
+        # its in/out channels (the shared ResNetBlock projects the shortcut
+        # when channels change between stages). Wrap in nnx.List so the blocks
+        # register as proper pytree children (required since Flax 0.12).
+        layers = []
+        in_ch = channels[0]
         for i, (num_block, channel) in enumerate(zip(num_blocks, channels)):
             stride = 1 if i == 0 else 2
             for j in range(num_block):
                 block_stride = stride if j == 0 else 1
-                self.layers.append(ResNetBlock(channel, block_stride, rngs))
+                layers.append(ResNetBlock(in_ch, channel, block_stride, rngs))
+                in_ch = channel
+        self.layers = nnx.List(layers)
         
         # Global average pooling and classifier
         self.fc = nnx.Linear(channels[-1], num_classes, rngs=rngs)

--- a/examples/training/language_model.py
+++ b/examples/training/language_model.py
@@ -158,10 +158,10 @@ class TransformerLM(nnx.Module):
         self.position_embedding = nnx.Embed(max_seq_len, d_model, rngs=rngs)
         
         # Transformer blocks
-        self.blocks = [
+        self.blocks = nnx.List([
             TransformerBlock(d_model, num_heads, d_ff, dropout, rngs)
             for _ in range(num_layers)
-        ]
+        ])
         
         # Output projection
         self.output_proj = nnx.Linear(d_model, vocab_size, rngs=rngs)

--- a/website/docs/research/reinforcement-learning.md
+++ b/website/docs/research/reinforcement-learning.md
@@ -562,19 +562,28 @@ obs, state, reward, done, info = env.step(key_step, state, action, env_params)
 gymnax enables fully JIT-compiled episode rollouts using `jax.lax.scan`:
 
 ```python
-from flax import linen as nn
+from flax import nnx
 
-class MLP(nn.Module):
+class PolicyMLP(nnx.Module):
     """Simple policy network."""
-    num_hidden_units: int
-    num_output_units: int
+    def __init__(self, in_features: int, num_hidden: int,
+                 num_actions: int, *, rngs: nnx.Rngs):
+        self.fc1 = nnx.Linear(in_features, num_hidden, rngs=rngs)
+        self.fc2 = nnx.Linear(num_hidden, num_actions, rngs=rngs)
 
-    @nn.compact
-    def __call__(self, x, key):
-        x = nn.Dense(self.num_hidden_units)(x)
-        x = nn.relu(x)
-        x = nn.Dense(self.num_output_units)(x)
-        return x
+    def __call__(self, x):
+        x = nnx.relu(self.fc1(x))
+        return self.fc2(x)
+
+# Split the NNX model into a static graph definition + its parameters, so the
+# params can be carried through jax.lax.scan as a plain pytree.
+policy = PolicyMLP(in_features=4, num_hidden=64, num_actions=2, rngs=nnx.Rngs(0))
+graphdef, policy_params = nnx.split(policy)
+
+def policy_fn(params, obs, key):
+    """Stateless policy call, rebuilt from (graphdef, params) inside the scan."""
+    model = nnx.merge(graphdef, params)
+    return model(obs)
 
 def gymnax_rollout(key, policy_fn, policy_params, steps_in_episode, env_name="CartPole-v1"):
     """JIT-compiled episode rollout with gymnax."""

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://mlnomadpy.github.io',
+  url: 'https://tahabouhsine.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/flaxdocs/',
@@ -52,7 +52,7 @@ const config: Config = {
         '@type': 'WebSite',
         name: 'Flax Training Docs',
         description: 'Comprehensive guide to training neural networks with Flax NNX and JAX',
-        url: 'https://mlnomadpy.github.io/flaxdocs/',
+        url: 'https://tahabouhsine.com/flaxdocs/',
       }),
     },
     {
@@ -64,8 +64,8 @@ const config: Config = {
         '@context': 'https://schema.org/',
         '@type': 'Organization',
         name: 'Flax Training Docs',
-        url: 'https://mlnomadpy.github.io/flaxdocs/',
-        logo: 'https://mlnomadpy.github.io/flaxdocs/img/logo.svg',
+        url: 'https://tahabouhsine.com/flaxdocs/',
+        logo: 'https://tahabouhsine.com/flaxdocs/img/logo.svg',
         description: 'Educational resource for learning Flax NNX and JAX neural network training',
         sameAs: [
           'https://github.com/mlnomadpy/flaxdocs',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+tahabouhsine.com

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -3,4 +3,4 @@ User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://mlnomadpy.github.io/flaxdocs/sitemap.xml
+Sitemap: https://tahabouhsine.com/flaxdocs/sitemap.xml


### PR DESCRIPTION
Two changes on top of the merged #23:

## 1. Serve docs from the custom domain
Point the production site at **https://tahabouhsine.com/flaxdocs/** instead of the `github.io` host:
- `docusaurus.config.ts` `url` → `https://tahabouhsine.com` (baseUrl stays `/flaxdocs/`)
- WebSite/Organization JSON-LD URLs + `robots.txt` sitemap reference updated
- Added `static/CNAME` (`tahabouhsine.com`) so GitHub Pages binds the domain
- Source-repo links (`github.com/mlnomadpy/flaxdocs`) intentionally unchanged

Sitemap will be at **https://tahabouhsine.com/flaxdocs/sitemap.xml** once deployed.

## 2. Recover stranded runtime fixes
The #23 squash-merge was taken before my final commit landed, so these **Flax 0.12 runtime-crash fixes never reached master**. Recovered here (cherry-pick):
- `gpt_training`, `bert_fineweb`, `language_model`, `fsdp_sharding`: sub-modules stored in plain Python lists/dicts crash at construction on Flax 0.12 (`unexpected data in static attribute`) — wrapped in `nnx.List`/`nnx.Dict`.
- `resnet_streaming`: reuse the shared `ResNetBlock` + track in/out channels per stage (fixes a channel-mismatch crash with the default `[64,128,256,512]`).
- `research/reinforcement-learning.md`: gymnax rollout policy converted Linen → NNX (`nnx.split`/`nnx.merge` through `jax.lax.scan`).

All five models verified building + forward-passing on CPU; site build passes.

> ⚠️ Deploying the custom domain also requires DNS (a `CNAME`/`ALIAS` for `tahabouhsine.com`) and setting the domain in the repo's **Settings → Pages**. This PR only handles the in-repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)