### PR TITLE
Applications: 21 new Flax NNX guides across generative, sequence, scientific, vision & adaptation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -94,11 +94,27 @@ examples/
 ├── imagenet/                        # ✅ Standalone app
 │   └── main.py
 │
+├── generative/                      # ✅ 4 examples (autoencoder, VAE, DCGAN, DDPM)
+│   ├── autoencoder.py
+│   ├── vae.py
+│   ├── dcgan.py
+│   └── ddpm.py
+│
+├── sequence/                        # ✅ 1 example (RNN/LSTM/GRU)
+│   └── rnn_cells.py
+│
+├── scientific/                      # ✅ 2 examples (GCN, PINN)
+│   ├── gcn_karate.py
+│   └── pinn_oscillator.py
+│
+├── adaptation/                      # ✅ 1 example (LoRA)
+│   └── lora_finetuning.py
+│
 ├── index.py                         # 📋 Complete example index
 └── requirements.txt                 # Updated with pytest
 ```
 
-**Total: 20 categorized examples + 1 standalone ImageNet app**
+**Total: 28 categorized examples + 1 standalone ImageNet app**
 
 ## 🚀 Quick Start
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,27 +94,40 @@ examples/
 ├── imagenet/                        # ✅ Standalone app
 │   └── main.py
 │
-├── generative/                      # ✅ 4 examples (autoencoder, VAE, DCGAN, DDPM)
+├── generative/                      # ✅ 5 examples (autoencoder, VAE, DCGAN, DDPM, flows)
 │   ├── autoencoder.py
 │   ├── vae.py
 │   ├── dcgan.py
-│   └── ddpm.py
+│   ├── ddpm.py
+│   └── normalizing_flows.py
 │
-├── sequence/                        # ✅ 1 example (RNN/LSTM/GRU)
-│   └── rnn_cells.py
+├── sequence/                        # ✅ 4 examples (RNN, seq2seq, time-series, word2vec)
+│   ├── rnn_cells.py
+│   ├── seq2seq_attention.py
+│   ├── time_series.py
+│   └── word2vec.py
 │
-├── scientific/                      # ✅ 2 examples (GCN, PINN)
+├── scientific/                      # ✅ 5 examples (GCN, PINN, Neural ODE, tabular, MoE)
 │   ├── gcn_karate.py
-│   └── pinn_oscillator.py
+│   ├── pinn_oscillator.py
+│   ├── neural_ode.py
+│   ├── tabular_dnn.py
+│   └── moe.py
 │
-├── adaptation/                      # ✅ 1 example (LoRA)
-│   └── lora_finetuning.py
+├── vision/                          # ✅ 2 examples (ViT, U-Net segmentation)
+│   ├── vit.py
+│   └── unet_segmentation.py
+│
+├── adaptation/                      # ✅ 2 examples (LoRA, CLIP)
+│   ├── lora_finetuning.py
+│   └── clip_toy.py
 │
 ├── index.py                         # 📋 Complete example index
 └── requirements.txt                 # Updated with pytest
 ```
 
-**Total: 28 categorized examples + 1 standalone ImageNet app**
+**Total: 41 categorized examples + 1 standalone ImageNet app** (advanced/ also gains
+metric-learning, interpretability, and uncertainty)
 
 ## 🚀 Quick Start
 

--- a/examples/adaptation/__init__.py
+++ b/examples/adaptation/__init__.py
@@ -1,0 +1,1 @@
+"""adaptation examples."""

--- a/examples/adaptation/clip_toy.py
+++ b/examples/adaptation/clip_toy.py
@@ -1,0 +1,240 @@
+"""
+Toy CLIP: Cross-Modal Contrastive Learning
+==========================================
+A minimal CLIP at toy scale: align synthetic "digit-like" images with their
+templated captions ("a photo of the digit N") in a shared embedding space using
+a symmetric InfoNCE (NT-Xent) loss over a batch.
+
+Run: python adaptation/clip_toy.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.models import ConvEncoder
+from shared.training_utils import compute_cross_entropy_loss
+
+
+# ==== VOCAB / CAPTION TEMPLATE ====
+# Every caption is "a photo of the digit <N>". Only the final token varies with
+# the class, so the text tower must learn to route the discriminative digit
+# token through mean-pooling. Shared word ids 0..4, digit-token id = 5 + class.
+_TEMPLATE_WORDS = ["a", "photo", "of", "the", "digit"]
+SEQ_LEN = len(_TEMPLATE_WORDS) + 1  # 5 template words + 1 digit token
+
+
+def build_captions(num_classes: int) -> jnp.ndarray:
+    """Token-id matrix of shape (num_classes, SEQ_LEN) for the caption template."""
+    template = jnp.arange(len(_TEMPLATE_WORDS))            # ids 0..4, shared
+    digit_tokens = len(_TEMPLATE_WORDS) + jnp.arange(num_classes)  # id 5 + c
+    template = jnp.broadcast_to(template, (num_classes, len(_TEMPLATE_WORDS)))
+    return jnp.concatenate([template, digit_tokens[:, None]], axis=1)
+
+
+def vocab_size(num_classes: int) -> int:
+    return len(_TEMPLATE_WORDS) + num_classes
+
+
+# ==== SYNTHETIC IMAGE PROTOTYPES ====
+
+def build_prototypes(key, num_classes: int, img_size: int = 28) -> jnp.ndarray:
+    """One fixed random "digit-like" pattern per class, in [0, 1].
+
+    Each class gets a distinct low-frequency blob so a small CNN can tell them
+    apart. Shape: (num_classes, img_size, img_size, 1).
+    """
+    raw = jax.random.normal(key, (num_classes, img_size, img_size, 1))
+    # Smooth with a 3x3 box blur so patterns look blob-like, not pure noise.
+    kernel = jnp.ones((3, 3, 1, 1)) / 9.0
+    raw = jax.lax.conv_general_dilated(
+        raw, kernel, window_strides=(1, 1), padding="SAME",
+        dimension_numbers=("NHWC", "HWIO", "NHWC"),
+    )
+    lo = raw.min(axis=(1, 2, 3), keepdims=True)
+    hi = raw.max(axis=(1, 2, 3), keepdims=True)
+    return (raw - lo) / (hi - lo + 1e-6)
+
+
+def try_mnist_prototypes(num_classes: int, img_size: int = 28):
+    """Best-effort per-class MEAN MNIST image (SYNTHETIC=0). Offline-safe.
+
+    Returns prototypes of shape (num_classes, img_size, img_size, 1) or None if
+    MNIST cannot be loaded (no network / tfds). Never raises.
+    """
+    try:  # pragma: no cover - non-default, environment dependent
+        import numpy as np
+        import tensorflow_datasets as tfds
+        ds = tfds.load("mnist", split="train", batch_size=-1)
+        data = tfds.as_numpy(ds)
+        images, labels = data["image"].astype("float32") / 255.0, data["label"]
+        protos = []
+        for c in range(num_classes):
+            protos.append(images[labels == (c % 10)].mean(axis=0))
+        return jnp.asarray(np.stack(protos))  # (num_classes, 28, 28, 1)
+    except Exception as exc:  # noqa: BLE001 - fall back to synthetic
+        print(f"  [SYNTHETIC=0] MNIST unavailable ({type(exc).__name__}); "
+              f"using synthetic prototypes instead.")
+        return None
+
+
+def make_batch(key, prototypes, captions, batch_size: int, noise: float = 0.15):
+    """Sample a batch of image-text pairs with DISTINCT classes.
+
+    Distinct classes keep the diagonal the unique correct pairing, so batch
+    retrieval accuracy is a clean signal. Returns a dict of jnp arrays.
+    """
+    num_classes = prototypes.shape[0]
+    k_cls, k_noise = jax.random.split(key)
+    replace = batch_size > num_classes
+    ids = jax.random.choice(k_cls, num_classes, (batch_size,), replace=replace)
+    images = prototypes[ids] + noise * jax.random.normal(k_noise, prototypes[ids].shape)
+    return {"image": images, "tokens": captions[ids], "labels": ids}
+
+
+# ==== MODEL ====
+
+class CLIPToy(nnx.Module):
+    """Two encoders projecting images and captions into one L2-normalized space.
+
+    Image tower: shared ConvEncoder (a small CNN) -> linear projection.
+    Text tower : nnx.Embed -> mean-pool over the sequence -> linear projection.
+    A fixed temperature scales the cosine-similarity logits (CLIP uses a
+    learnable log-scale; fixed keeps this toy's loss curve clean).
+    """
+
+    def __init__(self, num_classes: int, *, proj_dim: int = 64, embed_dim: int = 64,
+                 img_size: int = 28, base: int = 16, temperature: float = 0.07,
+                 rngs: nnx.Rngs):
+        self.temperature = temperature  # static (plain float): baked into jit
+
+        # Image tower: ConvEncoder halves H,W twice -> (img_size/4) spatial, base*2 ch.
+        self.image_encoder = ConvEncoder(in_channels=1, base=base, rngs=rngs)
+        feat_hw = img_size // 4
+        self.image_proj = nnx.Linear(base * 2 * feat_hw * feat_hw, proj_dim, rngs=rngs)
+
+        # Text tower: token embedding + mean-pool + projection.
+        self.token_embed = nnx.Embed(vocab_size(num_classes), embed_dim, rngs=rngs)
+        self.text_proj = nnx.Linear(embed_dim, proj_dim, rngs=rngs)
+
+    @staticmethod
+    def _l2_normalize(x):
+        return x / (jnp.linalg.norm(x, axis=-1, keepdims=True) + 1e-8)
+
+    def encode_image(self, images):
+        h = self.image_encoder(images)                 # (B, H/4, W/4, base*2)
+        h = h.reshape((h.shape[0], -1))                # flatten
+        return self._l2_normalize(self.image_proj(h))  # (B, proj_dim)
+
+    def encode_text(self, tokens):
+        emb = self.token_embed(tokens)                 # (B, SEQ_LEN, embed_dim)
+        emb = emb.mean(axis=1)                          # mean-pool over sequence
+        return self._l2_normalize(self.text_proj(emb))  # (B, proj_dim)
+
+    def __call__(self, images, tokens):
+        return self.encode_image(images), self.encode_text(tokens)
+
+
+# ==== CONTRASTIVE LOSS + METRIC ====
+
+def clip_loss(img_emb, txt_emb, temperature: float):
+    """Symmetric InfoNCE: cross-entropy in BOTH directions with a diagonal target.
+
+    logits[i, j] = <img_i, txt_j> / temperature. The correct pairing for row i
+    is column i, so the labels are arange(B) for image->text and, by symmetry,
+    for text->image on the transposed logits.
+    """
+    logits = (img_emb @ txt_emb.T) / temperature       # (B, B)
+    labels = jnp.arange(img_emb.shape[0])
+    loss_i2t = compute_cross_entropy_loss(logits, labels)      # image queries
+    loss_t2i = compute_cross_entropy_loss(logits.T, labels)    # text queries
+    return 0.5 * (loss_i2t + loss_t2i)
+
+
+def retrieval_accuracy(img_emb, txt_emb):
+    """Symmetric batch retrieval accuracy (argmax over each row == diagonal)."""
+    sims = img_emb @ txt_emb.T
+    labels = jnp.arange(img_emb.shape[0])
+    acc_i2t = jnp.mean(jnp.argmax(sims, axis=1) == labels)     # image->text
+    acc_t2i = jnp.mean(jnp.argmax(sims, axis=0) == labels)     # text->image
+    return 0.5 * (acc_i2t + acc_t2i)
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model: CLIPToy, optimizer: nnx.Optimizer, batch):
+    def loss_fn(model):
+        img_emb = model.encode_image(batch["image"])
+        txt_emb = model.encode_text(batch["tokens"])
+        loss = clip_loss(img_emb, txt_emb, model.temperature)
+        acc = retrieval_accuracy(img_emb, txt_emb)
+        return loss, acc
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+
+# ==== MAIN ====
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", "1"))
+    batch_size = int(os.environ.get("BATCH", "8"))
+    steps = int(os.environ.get("STEPS", "300"))
+    num_classes = int(os.environ.get("NUM_CLASSES", "10"))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+    img_size = 28
+
+    print("=" * 60)
+    print("Toy CLIP — cross-modal contrastive learning")
+    print("=" * 60)
+
+    # ---- data ----
+    key = jax.random.PRNGKey(0)
+    proto_key, data_key = jax.random.split(key)
+    prototypes = None
+    if not synthetic:
+        prototypes = try_mnist_prototypes(num_classes, img_size)
+    if prototypes is None:
+        prototypes = build_prototypes(proto_key, num_classes, img_size)
+    captions = build_captions(num_classes)
+    print(f"classes={num_classes}  vocab={vocab_size(num_classes)}  "
+          f"seq_len={SEQ_LEN}  batch={batch_size}  synthetic={synthetic}")
+
+    # ---- model + optimizer ----
+    model = CLIPToy(num_classes, img_size=img_size, rngs=nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+    n_params = sum(x.size for x in jax.tree.leaves(nnx.state(model, nnx.Param)))
+    print(f"trainable params: {n_params}")
+
+    # ---- train ----
+    print(f"\n[train] {epochs} epoch(s) x {steps} steps")
+    losses, accs = [], []
+    for epoch in range(epochs):
+        for step in range(steps):
+            data_key, k = jax.random.split(data_key)
+            batch = make_batch(k, prototypes, captions, batch_size)
+            loss, acc = train_step(model, optimizer, batch)
+            losses.append(float(loss))
+            accs.append(float(acc))
+            if step % 50 == 0:
+                print(f"  epoch {epoch} step {step:3d} | "
+                      f"loss {float(loss):.4f} | retrieval acc {float(acc):.3f}")
+
+    print("\n[assertions]")
+    print(f"  loss decreased:      {losses[-1]:.4f} < {losses[0]:.4f} -> "
+          f"{losses[-1] < losses[0]}")
+    print(f"  retrieval improved:  {accs[-1]:.3f} > {accs[0]:.3f} -> "
+          f"{accs[-1] > accs[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/adaptation/lora_finetuning.py
+++ b/examples/adaptation/lora_finetuning.py
@@ -1,0 +1,185 @@
+"""
+LoRA Parameter-Efficient Fine-Tuning
+====================================
+Adapt a pretrained MLP to a new task by training only tiny low-rank adapters
+while the base weights stay frozen (bit-identical), using nnx.LoRALinear.
+
+Run: python adaptation/lora_finetuning.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import compute_mse_loss
+
+
+# Filter that selects the FROZEN base weights: everything that is an nnx.Param
+# but NOT an nnx.LoRAParam. nnx.LoRAParam subclasses nnx.Param, so we must
+# subtract it explicitly (intersection via nnx.All, not the comma form which
+# would return two separate states).
+BASE_PARAMS = nnx.All(nnx.Param, nnx.Not(nnx.LoRAParam))
+
+
+# ==== MODEL ====
+
+class LoRAMLP(nnx.Module):
+    """Two-layer MLP whose Linear layers carry low-rank adapters.
+
+    Each nnx.LoRALinear holds a frozen base kernel/bias (nnx.Param) plus a
+    low-rank update A @ B stored as nnx.LoRAParam. At init B = 0, so the
+    adapter is a no-op and the module behaves exactly like a plain Linear.
+    """
+
+    def __init__(self, in_dim: int, hidden: int, out_dim: int, rank: int,
+                 *, rngs: nnx.Rngs):
+        self.l1 = nnx.LoRALinear(in_dim, hidden, lora_rank=rank, rngs=rngs)
+        self.l2 = nnx.LoRALinear(hidden, out_dim, lora_rank=rank, rngs=rngs)
+
+    def __call__(self, x):
+        return self.l2(nnx.relu(self.l1(x)))
+
+
+# ==== DATA ====
+
+def make_dataset(synthetic: bool = True, n: int = 256, in_dim: int = 8,
+                 out_dim: int = 4, seed: int = 0):
+    """Synthetic regression: shared inputs X, two targets for two tasks.
+
+    Task A is a random linear map Y_A = X @ W_A. Task B is the SAME inputs but
+    a rotated + shifted target Y_B = (Y_A @ R) + b, i.e. a domain shift of A.
+    This example is intrinsically synthetic (no downloads); `synthetic=False`
+    just draws a larger sample so the script always runs offline on CPU.
+
+    Returns tiny jnp arrays: (X, Y_A, Y_B).
+    """
+    if not synthetic:
+        n = max(n, 1024)
+    key = jax.random.PRNGKey(seed)
+    kx, ka, kr, kb = jax.random.split(key, 4)
+
+    X = jax.random.normal(kx, (n, in_dim))
+    W_a = jax.random.normal(ka, (in_dim, out_dim))
+    Y_a = X @ W_a
+
+    # Task B target = task A rotated (orthogonal R) and shifted by b.
+    R = jnp.linalg.qr(jax.random.normal(kr, (out_dim, out_dim)))[0]
+    b = jax.random.normal(kb, (out_dim,))
+    Y_b = Y_a @ R + b
+    return X, Y_a, Y_b
+
+
+# ==== PARAM UTILITIES ====
+
+def count_params(model: nnx.Module, filt) -> int:
+    """Total number of scalar parameters selected by `filt`."""
+    return int(sum(x.size for x in jax.tree.leaves(nnx.state(model, filt))))
+
+
+def snapshot(model: nnx.Module, filt):
+    """Deep copy of the arrays selected by `filt` (for before/after asserts)."""
+    return jax.tree.map(lambda a: jnp.array(a), nnx.state(model, filt))
+
+
+def trees_equal(a, b) -> bool:
+    """True iff every leaf pair is bit-identical."""
+    return all(bool(jnp.array_equal(x, y))
+               for x, y in zip(jax.tree.leaves(a), jax.tree.leaves(b)))
+
+
+# ==== TRAIN STEPS ====
+
+@nnx.jit
+def pretrain_step(model, optimizer, batch):
+    """Full fine-tuning on task A: trains ALL params (base + adapters)."""
+    def loss_fn(model):
+        preds = model(batch['x'])
+        loss = compute_mse_loss(preds, batch['y'])
+        return loss, preds
+    (loss, preds), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, preds
+
+
+@nnx.jit
+def adapt_step(model, optimizer, batch):
+    """Adapter-only fine-tuning on task B: trains ONLY nnx.LoRAParam.
+
+    Requires BOTH (1) an optimizer built with wrt=nnx.LoRAParam and (2) a
+    gradient restricted to the LoRAParam subtree via nnx.DiffState. Because
+    LoRAParam subclasses Param, the default wrt=nnx.Param would also move the
+    base weights.
+    """
+    def loss_fn(model):
+        preds = model(batch['x'])
+        loss = compute_mse_loss(preds, batch['y'])
+        return loss, preds
+    (loss, preds), grads = nnx.value_and_grad(
+        loss_fn, argnums=nnx.DiffState(0, nnx.LoRAParam), has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, preds
+
+
+# ==== MAIN ====
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", "1"))
+    batch = int(os.environ.get("BATCH", "128"))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+    pretrain_steps = int(os.environ.get("PRETRAIN_STEPS", "200"))
+    adapt_steps = int(os.environ.get("ADAPT_STEPS", "200"))
+
+    in_dim, hidden, out_dim, rank = 8, 64, 4, 4
+    X, Y_a, Y_b = make_dataset(synthetic=synthetic, n=batch, in_dim=in_dim,
+                               out_dim=out_dim)
+
+    rngs = nnx.Rngs(0)
+    model = LoRAMLP(in_dim, hidden, out_dim, rank, rngs=rngs)
+
+    n_lora = count_params(model, nnx.LoRAParam)
+    n_base = count_params(model, BASE_PARAMS)
+    total = n_lora + n_base
+    print(f"Base (frozen) params : {n_base}")
+    print(f"LoRA (trainable) params: {n_lora}  ({100.0 * n_lora / total:.1f}% of total)")
+
+    # ---- Phase 1: pretrain the whole model on task A (wrt=nnx.Param) ----
+    pre_opt = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+    print("\n[pretrain task A]")
+    for epoch in range(epochs):
+        for step in range(pretrain_steps):
+            loss, _ = pretrain_step(model, pre_opt, {'x': X, 'y': Y_a})
+        print(f"  epoch {epoch}: task-A MSE = {float(loss):.4f}")
+
+    # ---- Phase 2: freeze base, adapt to task B (wrt=nnx.LoRAParam) ----
+    base_before = snapshot(model, BASE_PARAMS)
+    lora_before = snapshot(model, nnx.LoRAParam)
+
+    adapt_opt = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.LoRAParam)
+    print("\n[adapt task B — LoRA only]")
+    b_losses = []
+    for epoch in range(epochs):
+        for step in range(adapt_steps):
+            loss, _ = adapt_step(model, adapt_opt, {'x': X, 'y': Y_b})
+            b_losses.append(float(loss))
+        print(f"  epoch {epoch}: task-B MSE = {float(loss):.4f}")
+
+    base_after = snapshot(model, BASE_PARAMS)
+    lora_after = snapshot(model, nnx.LoRAParam)
+
+    print("\n[assertions]")
+    print(f"  task-B MSE decreased: {b_losses[-1]:.4f} < {b_losses[0]:.4f} -> "
+          f"{b_losses[-1] < b_losses[0]}")
+    print(f"  base weights bit-identical: {trees_equal(base_before, base_after)}")
+    print(f"  LoRA weights changed: {not trees_equal(lora_before, lora_after)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/interpretability.py
+++ b/examples/advanced/interpretability.py
@@ -1,0 +1,250 @@
+"""
+Interpretability: Saliency, Integrated Gradients & Grad-CAM (Flax NNX)
+=====================================================================
+Attribute a CNN's prediction back to its input with three classic methods:
+vanilla gradient saliency, Integrated Gradients (with a completeness check),
+and Grad-CAM on a convolutional feature map. Trains a tiny CNN on
+self-contained synthetic shapes so the whole thing runs offline on CPU.
+
+Run: python advanced/interpretability.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import compute_cross_entropy_loss, compute_accuracy
+
+
+# ==== MODEL ====
+
+class SaliencyCNN(nnx.Module):
+    """A tiny CNN that exposes its last conv feature map.
+
+    The forward pass is split into two halves so gradients can be taken w.r.t.
+    either the INPUT (saliency / Integrated Gradients) or the intermediate
+    feature map A (Grad-CAM). A Global-Average-Pool head keeps the feature
+    extractor fully convolutional, which is exactly what Grad-CAM assumes:
+
+      x               (B, 28, 28, 1)
+      -> features()   -> A: (B, 14, 14, 32)     [target of Grad-CAM]
+      -> classify()   -> logits: (B, num_classes)
+    """
+
+    def __init__(self, num_classes: int = 3, *, rngs: nnx.Rngs):
+        self.conv1 = nnx.Conv(1, 16, kernel_size=(3, 3), rngs=rngs)
+        self.conv2 = nnx.Conv(16, 32, kernel_size=(3, 3), rngs=rngs)
+        self.fc1 = nnx.Linear(32, 64, rngs=rngs)
+        self.fc2 = nnx.Linear(64, num_classes, rngs=rngs)
+
+    def features(self, x):
+        """Input -> last conv feature map A (before the classifier head)."""
+        x = nnx.relu(self.conv1(x))
+        x = nnx.max_pool(x, window_shape=(2, 2), strides=(2, 2))   # 28 -> 14
+        x = nnx.relu(self.conv2(x))                                # (B, 14, 14, 32)
+        return x
+
+    def classify_from_features(self, feat):
+        """Feature map A -> class logits via Global Average Pooling + MLP."""
+        pooled = jnp.mean(feat, axis=(1, 2))          # GAP over space -> (B, 32)
+        h = nnx.relu(self.fc1(pooled))
+        return self.fc2(h)
+
+    def __call__(self, x, train: bool = False):
+        return self.classify_from_features(self.features(x))
+
+
+# ==== ATTRIBUTION METHODS ====
+
+def vanilla_saliency(model, x, target: int):
+    """Vanilla gradient saliency: |d logit_target / d input|.
+
+    x is a single image with a batch dim, shape (1, 28, 28, 1). The returned
+    saliency map has the SAME shape as the input.
+    """
+    def logit_fn(inp):
+        return model(inp)[0, target]              # scalar target logit
+    grad = jax.grad(logit_fn)(x)                  # d logit / d x, shape == x
+    return jnp.abs(grad)
+
+
+def integrated_gradients(model, x, target: int, baseline=None, steps: int = 256):
+    r"""Integrated Gradients along the straight-line path baseline -> x.
+
+        IG_i = (x_i - x'_i) * \int_0^1 (d f / d x_i)(x' + a (x - x')) da
+
+    The integral is approximated with the midpoint Riemann rule over `steps`
+    points. Satisfies the completeness axiom: IG.sum() ~= f(x) - f(baseline).
+    """
+    if baseline is None:
+        baseline = jnp.zeros_like(x)              # black-image baseline
+
+    def logit_fn(inp):
+        return model(inp)[0, target]
+    grad_fn = jax.grad(logit_fn)
+
+    # Midpoint rule: alphas at the centre of each of `steps` sub-intervals.
+    alphas = (jnp.arange(steps) + 0.5) / steps
+    interp = baseline + alphas[:, None, None, None, None] * (x - baseline)  # (S,1,28,28,1)
+    grads = jax.vmap(grad_fn)(interp)             # gradient at each point on the path
+    avg_grads = grads.mean(axis=0)                # approximates the path integral
+    return (x - baseline) * avg_grads
+
+
+def completeness_gap(model, x, target: int, ig, baseline=None):
+    """Return (IG.sum(), f(x) - f(baseline)) for the completeness axiom."""
+    if baseline is None:
+        baseline = jnp.zeros_like(x)
+    lhs = float(jnp.sum(ig))
+    rhs = float(model(x)[0, target] - model(baseline)[0, target])
+    return lhs, rhs
+
+
+def grad_cam(model, x, target: int):
+    """Grad-CAM: weight the conv feature map by its gradient importance.
+
+    1. A       = features(x)                       (1, 14, 14, K)
+    2. alpha_k = mean_{i,j} d logit_target / d A    (global-average-pooled grads)
+    3. CAM     = ReLU(sum_k alpha_k * A_k)         coarse (14x14) heatmap
+    4. upsample CAM to the input resolution and normalise to [0, 1].
+    """
+    feat = model.features(x)                      # (1, 14, 14, K)
+
+    def logit_fn(f):
+        return model.classify_from_features(f)[0, target]
+    grads = jax.grad(logit_fn)(feat)              # d logit / d A
+
+    weights = grads.mean(axis=(1, 2), keepdims=True)          # (1, 1, 1, K)
+    cam = nnx.relu(jnp.sum(weights * feat, axis=-1))          # (1, 14, 14)
+    cam = cam / (cam.max() + 1e-8)                            # normalise to [0, 1]
+    cam = jax.image.resize(cam, (cam.shape[0], x.shape[1], x.shape[2]),
+                           method='bilinear')                 # -> (1, 28, 28)
+    return cam
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    """One supervised gradient step (standard classification)."""
+    def loss_fn(model):
+        logits = model(batch['x'], train=True)
+        loss = compute_cross_entropy_loss(logits, batch['y'])
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, logits
+
+
+# ==== DATA ====
+
+# Three translation-invariant shape classes: a filled disk, a square outline,
+# and a plus sign. Class depends on SHAPE (not position), so a GAP-head CNN can
+# classify it while the shape lives at a random location the attributions
+# should recover.
+SHAPE_NAMES = ('disk', 'square-ring', 'plus')
+
+
+def make_dataset(n: int, key, noise: float = 0.1):
+    """Synthetic labelled images of shape (n, 28, 28, 1), values in [0, 1].
+
+    Each image draws one of three shapes at a random location, plus noise.
+    The shape's pixels are exactly what a good attribution map should recover.
+    """
+    ks = jax.random.split(key, 4)
+    labels = jax.random.randint(ks[0], (n,), 0, len(SHAPE_NAMES))
+    cy = jax.random.randint(ks[1], (n,), 8, 20).astype(jnp.float32)   # random centre
+    cx = jax.random.randint(ks[2], (n,), 8, 20).astype(jnp.float32)
+
+    yy, xx = jnp.meshgrid(jnp.arange(28), jnp.arange(28), indexing='ij')
+    dy = yy[None] - cy[:, None, None]
+    dx = xx[None] - cx[:, None, None]
+    dist = jnp.sqrt(dy ** 2 + dx ** 2)                 # Euclidean distance field
+    cheb = jnp.maximum(jnp.abs(dy), jnp.abs(dx))       # Chebyshev (square) field
+
+    disk = (dist <= 4.0).astype(jnp.float32)                                 # filled disk
+    ring = ((cheb <= 5) & (cheb >= 4)).astype(jnp.float32)                   # square outline
+    plus = (((jnp.abs(dy) <= 1) | (jnp.abs(dx) <= 1)) & (cheb <= 5)).astype(jnp.float32)
+    shapes = jnp.stack([disk, ring, plus], axis=0)     # (3, n, 28, 28)
+
+    img = shapes[labels, jnp.arange(n)]                # gather each image's shape
+    img = jnp.clip(img + noise * jax.random.normal(ks[3], (n, 28, 28)), 0.0, 1.0)
+    return img[..., None], labels                      # (n, 28, 28, 1), (n,)
+
+
+def make_batch(images, labels, idx):
+    return {'x': images[idx], 'y': labels[idx]}
+
+
+# ==== MAIN ====
+
+def main():
+    # Run-scale from env with small CPU-friendly defaults; SYNTHETIC by default.
+    epochs = int(os.environ.get('EPOCHS', 10))
+    batch = int(os.environ.get('BATCH', 64))
+    n = int(os.environ.get('N', 1024))
+    ig_steps = int(os.environ.get('IG_STEPS', 256))
+    _ = os.environ.get('SYNTHETIC', '1')          # data is always synthetic (offline)
+    num_classes = len(SHAPE_NAMES)
+
+    print("Interpretability: saliency / integrated gradients / Grad-CAM")
+    print(f"  epochs={epochs} batch={batch} n={n} classes={num_classes} "
+          f"ig_steps={ig_steps} shapes={SHAPE_NAMES}")
+
+    key = jax.random.key(0)
+    images, labels = make_dataset(n, key)
+    print(f"  dataset: {images.shape}  labels in [0, {num_classes - 1}]")
+
+    model = SaliencyCNN(num_classes=num_classes, rngs=nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    # --- Train the classifier (attribution is only meaningful once it learns) ---
+    perm_key = jax.random.key(1)
+    step = 0
+    for epoch in range(1, epochs + 1):
+        perm_key, sub = jax.random.split(perm_key)
+        order = jax.random.permutation(sub, n)
+        ep_loss, ep_acc, nb = 0.0, 0.0, 0
+        for start in range(0, n - batch + 1, batch):
+            idx = order[start:start + batch]
+            b = make_batch(images, labels, idx)
+            loss, logits = train_step(model, optimizer, b)
+            ep_loss += float(loss)
+            ep_acc += float(compute_accuracy(logits, b['y']))
+            nb += 1
+            step += 1
+        print(f"  epoch {epoch:2d}/{epochs} | steps {step:4d} | "
+              f"loss {ep_loss / nb:.4f} | acc {ep_acc / nb:.3f}")
+
+    # --- Attribute a single test image toward its predicted class ---
+    x = images[0:1]                                # (1, 28, 28, 1)
+    target = int(jnp.argmax(model(x)[0]))
+    print(f"\nExplaining image 0 (true shape '{SHAPE_NAMES[int(labels[0])]}', "
+          f"predicted '{SHAPE_NAMES[target]}')")
+
+    sal = vanilla_saliency(model, x, target)
+    print(f"  saliency map shape:   {sal.shape}  (== input {x.shape})")
+
+    ig = integrated_gradients(model, x, target, steps=ig_steps)
+    lhs, rhs = completeness_gap(model, x, target, ig)
+    rel = abs(lhs - rhs) / (abs(rhs) + 1e-8)
+    print(f"  integrated gradients: shape {ig.shape}")
+    print(f"    completeness: IG.sum()={lhs:+.6f}  f(x)-f(baseline)={rhs:+.6f}  "
+          f"|gap|={abs(lhs - rhs):.2e}  rel={rel:.2e}")
+
+    cam = grad_cam(model, x, target)
+    print(f"  grad-cam heatmap:     shape {cam.shape}  "
+          f"range [{float(cam.min()):.2f}, {float(cam.max()):.2f}]")
+
+    print("\nDone. Attributions localise the class-defining shape in the input.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/metric_learning.py
+++ b/examples/advanced/metric_learning.py
@@ -1,0 +1,270 @@
+"""
+Flax NNX: Metric Learning with a Siamese Network + Triplet Loss
+===============================================================
+Learn an embedding where same-class inputs land close together and
+different-class inputs are pushed apart, using a shared-weight (Siamese)
+embedding network trained with the triplet loss and in-batch hard mining.
+
+Run: python advanced/metric_learning.py
+
+Reference:
+    Schroff et al. "FaceNet: A Unified Embedding for Face Recognition and
+    Clustering" CVPR 2015. https://arxiv.org/abs/1503.03832
+    Hermans et al. "In Defense of the Triplet Loss for Person
+    Re-Identification" 2017. https://arxiv.org/abs/1703.07737
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.models import MLP
+
+
+# ============================================================================
+# 1. SIAMESE EMBEDDING NETWORK
+# ============================================================================
+
+class EmbeddingNet(nnx.Module):
+    """Shared-weight embedding network: input vector -> L2-normalized embedding.
+
+    A Siamese network is just ONE network applied to every input; the "shared
+    weights" come for free because we reuse the same module. The final
+    L2 normalization places every embedding on the unit hypersphere, so
+    squared Euclidean distance in [0, 4] and cosine distance agree up to a
+    constant and the margin has a consistent scale.
+    """
+
+    def __init__(self, in_features: int, hidden: int, embed_dim: int,
+                 *, rngs: nnx.Rngs, depth: int = 2):
+        # Reuse the shared MLP backbone; it maps (B, in_features) -> (B, embed_dim).
+        self.backbone = MLP(in_features, hidden, embed_dim, n_layers=depth,
+                            rngs=rngs, activation="relu")
+
+    def embed(self, x):
+        """Map a batch of inputs to unit-norm embeddings (B, embed_dim)."""
+        z = self.backbone(x)
+        return z / (jnp.linalg.norm(z, axis=-1, keepdims=True) + 1e-8)
+
+    def __call__(self, x, train: bool = False):
+        return self.embed(x)
+
+
+# ============================================================================
+# 2. TRIPLET LOSS + IN-BATCH HARD MINING
+# ============================================================================
+
+def pairwise_sq_dist(z):
+    """Squared Euclidean distance matrix D[i, j] = ||z_i - z_j||^2, shape (B, B)."""
+    sq = jnp.sum(z * z, axis=1)
+    d = sq[:, None] + sq[None, :] - 2.0 * (z @ z.T)
+    return jnp.maximum(d, 0.0)   # clip tiny negatives from round-off
+
+
+def batch_hard_triplet_loss(z, labels, margin: float = 0.2):
+    """Batch-hard triplet loss (Hermans et al. 2017).
+
+    For every anchor in the batch we mine, *within the same batch*:
+      - the HARDEST positive  = the same-class example that is FARTHEST away
+      - the HARDEST negative  = the different-class example that is CLOSEST
+    and push them to satisfy  d(a, p) + margin <= d(a, n):
+
+        L = mean_a  max(0,  d(a, p*) - d(a, n*) + margin)
+
+    Mining the hardest triplet in-batch is far more sample-efficient than
+    random triplets, most of which are already "easy" (loss 0) and contribute
+    no gradient. Returns (loss, fraction_of_active_triplets).
+    """
+    B = z.shape[0]
+    D = pairwise_sq_dist(z)
+
+    same = labels[:, None] == labels[None, :]
+    eye = jnp.eye(B, dtype=bool)
+    pos_mask = same & ~eye          # same class, excluding the anchor itself
+    neg_mask = ~same                # different class
+
+    # Hardest positive: largest distance among same-class examples.
+    hardest_pos = jnp.max(jnp.where(pos_mask, D, -jnp.inf), axis=1)
+    # Hardest negative: smallest distance among different-class examples.
+    hardest_neg = jnp.min(jnp.where(neg_mask, D, jnp.inf), axis=1)
+
+    losses = jax.nn.relu(hardest_pos - hardest_neg + margin)
+    frac_active = jnp.mean((losses > 0).astype(jnp.float32))
+    return jnp.mean(losses), frac_active
+
+
+# ============================================================================
+# 3. VERIFICATION METRIC (positive pairs closer than negative pairs)
+# ============================================================================
+
+def verification_accuracy(z, labels):
+    """Fraction of anchors whose MEAN same-class distance is smaller than their
+    MEAN different-class distance. A single scalar 'triplet loss decreasing' is
+    a poor progress signal for retrieval, so we track this ranking metric: it
+    starts near 0.5 (random) and rises toward 1.0 as classes separate.
+
+    Also returns (mean positive-pair distance, mean negative-pair distance).
+    """
+    B = z.shape[0]
+    D = pairwise_sq_dist(z)
+    same = labels[:, None] == labels[None, :]
+    eye = jnp.eye(B, dtype=bool)
+    pos_mask = (same & ~eye).astype(jnp.float32)
+    neg_mask = (~same).astype(jnp.float32)
+
+    mean_pos = (D * pos_mask).sum(1) / jnp.maximum(pos_mask.sum(1), 1.0)
+    mean_neg = (D * neg_mask).sum(1) / jnp.maximum(neg_mask.sum(1), 1.0)
+
+    acc = jnp.mean((mean_pos < mean_neg).astype(jnp.float32))
+    return acc, mean_pos.mean(), mean_neg.mean()
+
+
+# ============================================================================
+# 4. DATA (synthetic class-structured vectors by default; MNIST when SYNTHETIC=0)
+# ============================================================================
+
+def make_synthetic(n_classes: int = 10, per_class: int = 80, dim: int = 48,
+                   center_scale: float = 0.6, noise: float = 1.2, seed: int = 0):
+    """Class-structured vectors: each class is a random center + Gaussian noise.
+
+    Offline, self-contained, and deliberately OVERLAPPING (small center scale,
+    large noise) so the raw input is only weakly separable and the network has
+    to *learn* a good embedding rather than read the class off the input.
+    """
+    rng = np.random.default_rng(seed)
+    centers = rng.normal(size=(n_classes, dim)) * center_scale
+    X, Y = [], []
+    for c in range(n_classes):
+        pts = centers[c] + rng.normal(size=(per_class, dim)) * noise
+        X.append(pts)
+        Y.extend([c] * per_class)
+    X = np.concatenate(X, axis=0).astype(np.float32)
+    Y = np.array(Y, dtype=np.int32)
+    return X, Y, dim, n_classes
+
+
+def make_mnist(n: int = 3000):
+    """Real MNIST (flattened to 784-dim vectors) when SYNTHETIC=0. Needs tfds."""
+    import tensorflow_datasets as tfds
+    import tensorflow as tf
+    tf.config.set_visible_devices([], 'GPU')
+    ds = tfds.load('mnist', split=f'train[:{n}]', as_supervised=True)
+    xs, ys = [], []
+    for img, lab in tfds.as_numpy(ds):
+        xs.append(img.reshape(-1).astype(np.float32) / 255.0)
+        ys.append(int(lab))
+    return np.stack(xs), np.array(ys, dtype=np.int32), 784, 10
+
+
+def build_class_index(Y):
+    """Map each class label -> array of row indices (for PK batch sampling)."""
+    return {int(c): np.where(Y == c)[0] for c in np.unique(Y)}
+
+
+def make_pk_batch(X, Y, class_to_idx, P: int, K: int, rng):
+    """Sample a balanced 'PK' batch: P classes, K examples each (batch = P*K).
+
+    Balanced batches guarantee that every anchor has both positives (K-1 of
+    them) and negatives, which is exactly what in-batch mining needs.
+    """
+    classes = rng.choice(list(class_to_idx.keys()), size=P, replace=False)
+    idxs = []
+    for c in classes:
+        pool = class_to_idx[int(c)]
+        pick = rng.choice(pool, size=K, replace=len(pool) < K)
+        idxs.extend(pick.tolist())
+    idxs = np.array(idxs)
+    return {'x': jnp.asarray(X[idxs]), 'y': jnp.asarray(Y[idxs])}
+
+
+# ============================================================================
+# 5. TRAIN STEP
+# ============================================================================
+
+@nnx.jit
+def train_step(model, optimizer, batch, margin: float = 0.2):
+    """One gradient step of triplet-loss metric learning."""
+    def loss_fn(model):
+        z = model.embed(batch['x'])                       # (B, embed_dim), unit norm
+        loss, frac_active = batch_hard_triplet_loss(z, batch['y'], margin)
+        return loss, frac_active
+
+    (loss, frac_active), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, frac_active
+
+
+# ============================================================================
+# 6. MAIN
+# ============================================================================
+
+def main():
+    # Run-scale from env with small CPU-friendly defaults; SYNTHETIC by default.
+    epochs = int(os.environ.get('EPOCHS', 8))
+    batch = int(os.environ.get('BATCH', 64))
+    synthetic = os.environ.get('SYNTHETIC', '1') != '0'
+    margin = float(os.environ.get('MARGIN', 0.2))
+    embed_dim = int(os.environ.get('EMBED', 32))
+    hidden = int(os.environ.get('HIDDEN', 128))
+
+    if synthetic:
+        X, Y, in_features, n_classes = make_synthetic()
+    else:
+        X, Y, in_features, n_classes = make_mnist()
+
+    class_to_idx = build_class_index(Y)
+
+    # Balanced PK sampling: P classes x K examples per batch.
+    P = min(n_classes, 8)
+    K = max(2, batch // P)
+    pk = P * K
+    steps_per_epoch = max(1, X.shape[0] // pk)
+
+    print(f"Metric learning (Siamese + triplet loss) on "
+          f"{'synthetic class-structured vectors' if synthetic else 'MNIST'}")
+    print(f"  data: X={X.shape} classes={n_classes} | in_features={in_features}")
+    print(f"  epochs={epochs} batch={pk} (P={P} classes x K={K}) "
+          f"embed_dim={embed_dim} margin={margin}")
+
+    model = EmbeddingNet(in_features, hidden, embed_dim, rngs=nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+    n_params = sum(x.size for x in jax.tree_util.tree_leaves(nnx.state(model, nnx.Param)))
+    print(f"  model: EmbeddingNet with {n_params} parameters\n")
+
+    # Fixed balanced batch used to report the verification metric each epoch.
+    eval_rng = np.random.default_rng(123)
+    eval_batch = make_pk_batch(X, Y, class_to_idx, P, min(K + 4, 12), eval_rng)
+
+    rng = np.random.default_rng(0)
+    step = 0
+    for epoch in range(1, epochs + 1):
+        ep_loss, ep_active, nb = 0.0, 0.0, 0
+        for _ in range(steps_per_epoch):
+            b = make_pk_batch(X, Y, class_to_idx, P, K, rng)
+            loss, frac_active = train_step(model, optimizer, b, margin)
+            ep_loss += float(loss)
+            ep_active += float(frac_active)
+            nb += 1
+            step += 1
+
+        z_eval = model.embed(eval_batch['x'])
+        acc, dpos, dneg = verification_accuracy(z_eval, eval_batch['y'])
+        print(f"  epoch {epoch:2d}/{epochs} | step {step:4d} | "
+              f"triplet {ep_loss / nb:.4f} | active {ep_active / nb:.2f} | "
+              f"ver_acc {float(acc):.3f} | d+ {float(dpos):.3f} d- {float(dneg):.3f}")
+
+    print("\nDone. The embedding pulls same-class inputs together and pushes "
+          "different-class inputs apart (d+ < d-).")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/uncertainty.py
+++ b/examples/advanced/uncertainty.py
@@ -1,0 +1,281 @@
+"""
+Flax NNX: Uncertainty Estimation (MC-Dropout + Deep Ensembles)
+==============================================================
+Estimate predictive uncertainty on a 1D heteroscedastic regression task and
+decompose it into aleatoric (data noise) and epistemic (model) components.
+Both a single Monte-Carlo Dropout network and a vmapped deep ensemble show
+uncertainty growing away from the training data.
+
+Run: python advanced/uncertainty.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# ============================================================================
+# 1. SYNTHETIC HETEROSCEDASTIC 1D DATA
+# ============================================================================
+# Training inputs live in two clusters, [-4, -2] and [2, 4], leaving a gap in
+# the middle and unobserved regions in the tails. A well-calibrated model
+# should report LOW uncertainty inside the clusters and HIGH uncertainty in
+# the gap and the extrapolation regions.
+
+
+def true_fn(x):
+    """Underlying clean function (no noise)."""
+    return jnp.sin(1.5 * x) + 0.1 * x
+
+
+def noise_std(x):
+    """Heteroscedastic aleatoric noise: larger for larger |x|."""
+    return 0.05 + 0.05 * jnp.abs(x)
+
+
+def make_regression_data(key, n_per_cluster=60):
+    """Sample training data from two clusters with input-dependent noise."""
+    k1, k2, k3 = jax.random.split(key, 3)
+    x_left = jax.random.uniform(k1, (n_per_cluster, 1), minval=-4.0, maxval=-2.0)
+    x_right = jax.random.uniform(k2, (n_per_cluster, 1), minval=2.0, maxval=4.0)
+    x = jnp.concatenate([x_left, x_right], axis=0)
+    eps = jax.random.normal(k3, x.shape) * noise_std(x)
+    y = true_fn(x) + eps
+    return x, y
+
+
+# ============================================================================
+# 2. GAUSSIAN MLP WITH DROPOUT (mean + variance heads)
+# ============================================================================
+# The network predicts a Gaussian per input: a mean mu(x) and a log-variance
+# s(x) = log sigma^2(x). The variance head captures ALEATORIC noise; the
+# dropout layers make the network stochastic so repeated forward passes
+# reveal EPISTEMIC uncertainty (MC-Dropout).
+
+
+class GaussianMLP(nnx.Module):
+    """MLP that outputs (mu, log_var) with dropout for MC sampling."""
+
+    def __init__(
+        self,
+        in_features: int = 1,
+        hidden: int = 64,
+        dropout_rate: float = 0.1,
+        *,
+        rngs: nnx.Rngs,
+    ):
+        self.l1 = nnx.Linear(in_features, hidden, rngs=rngs)
+        self.l2 = nnx.Linear(hidden, hidden, rngs=rngs)
+        self.drop = nnx.Dropout(dropout_rate, rngs=rngs)
+        self.mu_head = nnx.Linear(hidden, 1, rngs=rngs)
+        self.logvar_head = nnx.Linear(hidden, 1, rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        h = nnx.relu(self.l1(x))
+        h = self.drop(h, deterministic=not train)
+        h = nnx.relu(self.l2(h))
+        h = self.drop(h, deterministic=not train)
+        mu = self.mu_head(h)
+        # Clamp log-variance for numerical stability (sigma^2 in ~[e^-6, e^4]).
+        log_var = jnp.clip(self.logvar_head(h), -6.0, 4.0)
+        return mu, log_var
+
+
+# ============================================================================
+# 3. GAUSSIAN NEGATIVE LOG-LIKELIHOOD LOSS
+# ============================================================================
+# Training a mean+variance head with the Gaussian NLL lets the network learn
+# input-dependent (heteroscedastic) noise instead of a single global sigma.
+
+
+def gaussian_nll(mu, log_var, y):
+    """Mean Gaussian negative log-likelihood (drops the constant term)."""
+    inv_var = jnp.exp(-log_var)
+    return 0.5 * jnp.mean(log_var + (y - mu) ** 2 * inv_var)
+
+
+# ============================================================================
+# 4. SINGLE-MODEL TRAIN STEP (used for MC-Dropout)
+# ============================================================================
+
+
+@nnx.jit
+def train_step(model: GaussianMLP, optimizer: nnx.Optimizer, batch):
+    def loss_fn(model):
+        mu, log_var = model(batch["x"], train=True)
+        loss = gaussian_nll(mu, log_var, batch["y"])
+        return loss, mu
+
+    (loss, mu), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, mu
+
+
+# ============================================================================
+# 5. MC-DROPOUT INFERENCE
+# ============================================================================
+# Keep dropout ON at test time (train=True) and run T stochastic passes. Each
+# call advances the dropout RNG, so the T predictions differ. Decompose:
+#     predictive mean = mean_t mu_t
+#     aleatoric       = mean_t sigma_t^2          (average predicted noise)
+#     epistemic       = var_t(mu_t)               (disagreement across passes)
+#     total           = aleatoric + epistemic
+
+
+@nnx.jit
+def _mc_forward(model, x):
+    return model(x, train=True)  # dropout active
+
+
+def mc_predict(model, x, n_samples: int = 30):
+    mus, variances = [], []
+    for _ in range(n_samples):
+        mu, log_var = _mc_forward(model, x)
+        mus.append(mu)
+        variances.append(jnp.exp(log_var))
+    mus = jnp.stack(mus)            # (T, N, 1)
+    variances = jnp.stack(variances)
+    mean = mus.mean(axis=0)
+    aleatoric = variances.mean(axis=0)
+    epistemic = mus.var(axis=0)
+    return {
+        "mean": mean,
+        "aleatoric": aleatoric,
+        "epistemic": epistemic,
+        "total": aleatoric + epistemic,
+        "samples": mus,
+    }
+
+
+# ============================================================================
+# 6. DEEP ENSEMBLE via nnx.vmap
+# ============================================================================
+# Build M independently-initialized networks (and their optimizers) with a
+# single vmapped constructor, then train all M in one vmapped step. Each member
+# sees a bootstrap resample of the data, so members disagree where data is
+# scarce -> epistemic uncertainty.
+
+
+@nnx.vmap(in_axes=0, out_axes=0)
+def make_ensemble(key):
+    """Build one independently-initialized member + its optimizer per key."""
+    model = GaussianMLP(dropout_rate=0.1, rngs=nnx.Rngs(key))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+    return model, optimizer
+
+
+@nnx.vmap(in_axes=(0, 0, 0), out_axes=0)
+def ensemble_train_step(model, optimizer, batch):
+    def loss_fn(model):
+        mu, log_var = model(batch["x"], train=True)
+        return gaussian_nll(mu, log_var, batch["y"])
+
+    loss, grads = nnx.value_and_grad(loss_fn)(model)
+    optimizer.update(model, grads)
+    return loss
+
+
+@nnx.vmap(in_axes=(0, None), out_axes=0)
+def _ensemble_forward(model, x):
+    return model(x, train=False)  # deterministic; diversity comes from params
+
+
+def ensemble_predict(models, x):
+    mu, log_var = _ensemble_forward(models, x)  # each (M, N, 1)
+    variances = jnp.exp(log_var)
+    mean = mu.mean(axis=0)
+    aleatoric = variances.mean(axis=0)
+    epistemic = mu.var(axis=0)
+    return {
+        "mean": mean,
+        "aleatoric": aleatoric,
+        "epistemic": epistemic,
+        "total": aleatoric + epistemic,
+        "members": mu,
+    }
+
+
+def bootstrap_batches(key, x, y, n_models):
+    """Resample (x, y) with replacement for each ensemble member -> (M, N, 1)."""
+    n = x.shape[0]
+    keys = jax.random.split(key, n_models)
+    idx = jax.vmap(lambda k: jax.random.randint(k, (n,), 0, n))(keys)  # (M, N)
+    return x[idx], y[idx]
+
+
+# ============================================================================
+# 7. MAIN
+# ============================================================================
+
+
+def _region_uncertainty(x_grid, epistemic):
+    """Average epistemic uncertainty inside vs. outside the training clusters."""
+    x = x_grid.ravel()
+    e = epistemic.ravel()
+    in_cluster = ((x >= -4) & (x <= -2)) | ((x >= 2) & (x <= 4))
+    out_region = ~in_cluster
+    return float(e[in_cluster].mean()), float(e[out_region].mean())
+
+
+def main():
+    steps = int(os.environ.get("EPOCHS", 500))
+    batch_size = int(os.environ.get("BATCH", 64))
+    n_models = int(os.environ.get("N_MODELS", 5))
+    n_samples = int(os.environ.get("MC_SAMPLES", 30))
+    _ = os.environ.get("SYNTHETIC", "1")  # data is always synthetic/offline
+
+    print("=" * 70)
+    print("UNCERTAINTY ESTIMATION: MC-Dropout + Deep Ensembles")
+    print("=" * 70)
+
+    key = jax.random.key(0)
+    dkey, tkey, bkey = jax.random.split(key, 3)
+    x_train, y_train = make_regression_data(dkey)
+    print(f"Training points: {x_train.shape[0]} (two clusters, heteroscedastic noise)")
+
+    x_grid = jnp.linspace(-7.0, 7.0, 200).reshape(-1, 1)
+
+    # ---- MC-Dropout: train ONE stochastic network --------------------------
+    print("\n[1/2] Training a single MC-Dropout network...")
+    model = GaussianMLP(dropout_rate=0.1, rngs=nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+    for step in range(steps):
+        bkey, sub = jax.random.split(bkey)
+        idx = jax.random.randint(sub, (batch_size,), 0, x_train.shape[0])
+        loss, _ = train_step(model, optimizer, {"x": x_train[idx], "y": y_train[idx]})
+        if (step + 1) % max(1, steps // 5) == 0:
+            print(f"  step {step + 1:4d}/{steps} | NLL {float(loss):.4f}")
+
+    mc = mc_predict(model, x_grid, n_samples=n_samples)
+    mc_in, mc_out = _region_uncertainty(x_grid, mc["epistemic"])
+    print(f"  MC-Dropout epistemic: in-cluster {mc_in:.5f} | away {mc_out:.5f}")
+
+    # ---- Deep Ensemble: train M networks with one vmapped step -------------
+    print(f"\n[2/2] Training a deep ensemble of {n_models} networks (nnx.vmap)...")
+    keys = jax.random.split(tkey, n_models)
+    models, optimizers = make_ensemble(keys)
+    xb, yb = bootstrap_batches(bkey, x_train, y_train, n_models)
+    ens_batch = {"x": xb, "y": yb}
+    for step in range(steps * 2):
+        losses = ensemble_train_step(models, optimizers, ens_batch)
+        if (step + 1) % max(1, (steps * 2) // 5) == 0:
+            print(f"  step {step + 1:4d}/{steps * 2} | mean NLL {float(losses.mean()):.4f}")
+
+    ens = ensemble_predict(models, x_grid)
+    ens_in, ens_out = _region_uncertainty(x_grid, ens["epistemic"])
+    print(f"  Ensemble epistemic:   in-cluster {ens_in:.5f} | away {ens_out:.5f}")
+
+    print("\n" + "=" * 70)
+    print("Uncertainty grows away from the training data for BOTH methods.")
+    print("Aleatoric captures data noise; epistemic captures model ignorance.")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generative/__init__.py
+++ b/examples/generative/__init__.py
@@ -1,0 +1,1 @@
+"""generative examples."""

--- a/examples/generative/autoencoder.py
+++ b/examples/generative/autoencoder.py
@@ -1,0 +1,162 @@
+"""
+Convolutional Autoencoder (+ Denoising) on MNIST with Flax NNX
+==============================================================
+Compress 28x28 images through a small latent bottleneck and reconstruct them
+with learned upsampling (nnx.ConvTranspose). Flip one flag to turn the plain
+autoencoder into a denoising autoencoder that cleans up noisy inputs.
+
+Run: python generative/autoencoder.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.models import ConvEncoder, ConvDecoder
+from shared.training_utils import bce_loss
+
+
+# ==== MODEL ====
+
+class ConvAutoencoder(nnx.Module):
+    """Encoder -> Linear bottleneck -> Decoder.
+
+    Forward pass:
+      x            (B, 28, 28, in_ch)
+      -> ConvEncoder                 -> (B, 7, 7, base*2)
+      -> flatten + Linear            -> (B, latent_dim)   [the bottleneck]
+      -> ConvDecoder (ConvTranspose) -> (B, 28, 28, in_ch) LOGITS
+    """
+
+    def __init__(self, latent_dim: int = 32, base: int = 16,
+                 in_channels: int = 1, *, rngs: nnx.Rngs):
+        self.enc_hw = 7                      # 28 -> 14 -> 7 after two stride-2 convs
+        self.enc_channels = base * 2         # ConvEncoder doubles `base`
+        self.encoder = ConvEncoder(in_channels, base, rngs=rngs)
+        # Bottleneck: squeeze the (7*7*base*2) feature map into `latent_dim`.
+        self.bottleneck = nnx.Linear(
+            self.enc_channels * self.enc_hw * self.enc_hw, latent_dim, rngs=rngs
+        )
+        # Decoder mirrors the encoder and returns LOGITS (no final activation).
+        self.decoder = ConvDecoder(latent_dim, base, in_channels,
+                                   start_hw=self.enc_hw, rngs=rngs)
+
+    def encode(self, x):
+        h = self.encoder(x)                  # (B, 7, 7, base*2)
+        h = h.reshape(h.shape[0], -1)        # (B, 7*7*base*2)
+        return self.bottleneck(h)            # (B, latent_dim)
+
+    def __call__(self, x, train: bool = False):
+        z = self.encode(x)                   # bottleneck code
+        return self.decoder(z)               # (B, 28, 28, in_ch) logits
+
+
+# ==== NOISE (for the denoising variant) ====
+
+def add_gaussian_noise(x, key, std: float):
+    """Corrupt inputs with Gaussian noise, then clip back to [0, 1]."""
+    noisy = x + std * jax.random.normal(key, x.shape)
+    return jnp.clip(noisy, 0.0, 1.0)
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    """One gradient step. batch['x'] is the (possibly noisy) input,
+    batch['target'] is the CLEAN image we reconstruct against."""
+    def loss_fn(model):
+        logits = model(batch['x'], train=True)          # (B, 28, 28, in_ch)
+        loss = bce_loss(logits, batch['target'])        # sigmoid-BCE per pixel
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, logits
+
+
+# ==== DATA ====
+
+def make_dataset(synthetic: bool = True, n: int = 512, seed: int = 0):
+    """Return CLEAN images of shape (n, 28, 28, 1) in [0, 1].
+
+    synthetic=True  -> binarized random blobs (offline, no downloads).
+    synthetic=False -> real MNIST via tfds, scaled to [0, 1].
+    """
+    if synthetic:
+        key = jax.random.key(seed)
+        # Smooth-ish random fields, then binarize: values are exactly {0, 1}.
+        raw = jax.random.uniform(key, (n, 28, 28, 1))
+        images = (raw > 0.5).astype(jnp.float32)
+        return images
+    else:
+        import tensorflow_datasets as tfds
+        import tensorflow as tf
+        tf.config.set_visible_devices([], 'GPU')
+        ds = tfds.load('mnist', split=f'train[:{n}]', as_supervised=True)
+        imgs = [tf.cast(img, tf.float32).numpy() / 255.0 for img, _ in tfds.as_numpy(ds)]
+        return jnp.asarray(imgs).reshape(-1, 28, 28, 1)
+
+
+def make_batch(images, idx, *, denoising: bool, noise_std: float, key):
+    """Slice a batch and build {'x': input, 'target': clean image}."""
+    clean = images[idx]
+    if denoising:
+        x = add_gaussian_noise(clean, key, noise_std)
+    else:
+        x = clean
+    return {'x': x, 'target': clean}
+
+
+# ==== MAIN ====
+
+def main():
+    # Run-scale from env with small CPU-friendly defaults; SYNTHETIC by default.
+    epochs = int(os.environ.get('EPOCHS', 4))
+    batch = int(os.environ.get('BATCH', 64))
+    synthetic = os.environ.get('SYNTHETIC', '1') != '0'
+    denoising = os.environ.get('DENOISE', '0') != '0'
+    noise_std = float(os.environ.get('NOISE_STD', 0.5))
+    latent_dim = int(os.environ.get('LATENT', 32))
+
+    mode = 'DENOISING autoencoder' if denoising else 'autoencoder'
+    print(f"Convolutional {mode} on {'synthetic' if synthetic else 'MNIST'} data")
+    print(f"  epochs={epochs} batch={batch} latent_dim={latent_dim} "
+          f"noise_std={noise_std if denoising else 0}")
+
+    images = make_dataset(synthetic=synthetic)
+    n = images.shape[0]
+    print(f"  dataset: {images.shape}  (clean targets in [0, 1])")
+
+    model = ConvAutoencoder(latent_dim=latent_dim, rngs=nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    key = jax.random.key(1)
+    step = 0
+    for epoch in range(1, epochs + 1):
+        key, perm_key = jax.random.split(key)
+        order = jax.random.permutation(perm_key, n)
+        epoch_loss, nb = 0.0, 0
+        for start in range(0, n - batch + 1, batch):
+            idx = order[start:start + batch]
+            key, noise_key = jax.random.split(key)
+            b = make_batch(images, idx, denoising=denoising,
+                           noise_std=noise_std, key=noise_key)
+            loss, _ = train_step(model, optimizer, b)
+            epoch_loss += float(loss)
+            nb += 1
+            step += 1
+        print(f"  epoch {epoch:2d}/{epochs} | steps {step:4d} | "
+              f"BCE {epoch_loss / max(nb, 1):8.2f}")
+
+    print("Done. The decoder's nnx.ConvTranspose layers upsample 7->14->28.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generative/dcgan.py
+++ b/examples/generative/dcgan.py
@@ -1,0 +1,180 @@
+"""
+DCGAN on MNIST with Flax NNX
+============================
+A Deep Convolutional GAN: a transpose-conv Generator and a spectral-normalized
+Discriminator play the adversarial minimax game, trained with two optimizers
+and the non-saturating generator loss.
+
+Run: python generative/dcgan.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import bce_loss
+
+
+# ==== MODELS ====
+
+class Generator(nnx.Module):
+    """Maps a latent vector z -> a 28x28x1 image in [-1, 1].
+
+    Linear(z_dim -> 32*7*7) -> reshape (7,7,32)
+      -> ConvTranspose 7->14 (32->16, relu)
+      -> ConvTranspose 14->28 (16->1) -> tanh
+    """
+
+    def __init__(self, z_dim: int = 64, base: int = 16, *, rngs: nnx.Rngs):
+        self.z_dim = z_dim
+        self.fc = nnx.Linear(z_dim, base * 2 * 7 * 7, rngs=rngs)
+        self.deconv1 = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                         strides=(2, 2), padding='SAME', rngs=rngs)  # 7 -> 14
+        self.deconv2 = nnx.ConvTranspose(base, 1, kernel_size=(3, 3),
+                                         strides=(2, 2), padding='SAME', rngs=rngs)  # 14 -> 28
+        self.base = base
+
+    def __call__(self, z):
+        h = self.fc(z)
+        h = h.reshape(z.shape[0], 7, 7, self.base * 2)
+        h = nnx.relu(self.deconv1(h))
+        h = self.deconv2(h)
+        return nnx.tanh(h)   # outputs in [-1, 1]
+
+
+class Discriminator(nnx.Module):
+    """Classifies 28x28x1 images as real (high logit) or fake (low logit).
+
+    Every conv/linear kernel is wrapped in ``nnx.SpectralNorm`` to bound the
+    Lipschitz constant, which stabilizes the adversarial game.
+    """
+
+    def __init__(self, base: int = 16, *, rngs: nnx.Rngs):
+        # Spectral-normalized conv stack (stride 2, leaky_relu).
+        self.conv1 = nnx.SpectralNorm(
+            nnx.Conv(1, base, kernel_size=(3, 3), strides=(2, 2),
+                     padding='SAME', rngs=rngs), rngs=rngs)          # 28 -> 14
+        self.conv2 = nnx.SpectralNorm(
+            nnx.Conv(base, base * 2, kernel_size=(3, 3), strides=(2, 2),
+                     padding='SAME', rngs=rngs), rngs=rngs)          # 14 -> 7
+        # Spectral-normalized linear head -> single logit.
+        self.fc = nnx.SpectralNorm(
+            nnx.Linear(base * 2 * 7 * 7, 1, rngs=rngs), rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        # update_stats only when we are actually training the discriminator.
+        x = nnx.leaky_relu(self.conv1(x, update_stats=train), negative_slope=0.2)
+        x = nnx.leaky_relu(self.conv2(x, update_stats=train), negative_slope=0.2)
+        x = x.reshape(x.shape[0], -1)
+        return self.fc(x, update_stats=train)   # (B, 1) logit
+
+
+# ==== DATA ====
+
+def sample_z(key, batch: int, z_dim: int):
+    """Draw a batch of standard-normal latent vectors."""
+    return jax.random.normal(key, (batch, z_dim))
+
+
+def make_dataset(synthetic: bool = True, n: int = 512):
+    """Return real images as (N, 28, 28, 1) float array scaled to [-1, 1].
+
+    Synthetic mode fabricates smooth blob patterns so the script runs offline;
+    set SYNTHETIC=0 to stream real MNIST via tfds.
+    """
+    if synthetic:
+        key = jax.random.PRNGKey(0)
+        # A few smooth Gaussian blobs -> non-trivial but cheap structure.
+        ys, xs = jnp.meshgrid(jnp.linspace(-1, 1, 28), jnp.linspace(-1, 1, 28),
+                              indexing='ij')
+        centers = jax.random.uniform(key, (n, 2), minval=-0.5, maxval=0.5)
+        imgs = jnp.exp(-((xs[None] - centers[:, 0, None, None]) ** 2
+                         + (ys[None] - centers[:, 1, None, None]) ** 2) / 0.1)
+        imgs = imgs * 2.0 - 1.0                      # [0,1] -> [-1,1]
+        return imgs[..., None]                        # (N, 28, 28, 1)
+
+    import tensorflow_datasets as tfds
+    import tensorflow as tf
+    tf.config.set_visible_devices([], 'GPU')
+    ds = tfds.load('mnist', split='train', batch_size=-1)
+    imgs = jnp.asarray(tfds.as_numpy(ds)['image'], dtype=jnp.float32) / 255.0
+    return imgs * 2.0 - 1.0                            # (N, 28, 28, 1) in [-1,1]
+
+
+# ==== TRAIN STEPS ====
+
+@nnx.jit
+def d_step(gen, disc, opt_d, real, z):
+    """Update the discriminator: push real logits up, fake logits down."""
+    fake = gen(z)   # generator is fixed here (not in the grad set)
+
+    def loss_fn(disc):
+        real_logits = disc(real, train=True)
+        fake_logits = disc(fake, train=True)
+        loss = (bce_loss(real_logits, jnp.ones_like(real_logits))
+                + bce_loss(fake_logits, jnp.zeros_like(fake_logits)))
+        return loss, (real_logits, fake_logits)
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(disc)
+    opt_d.update(disc, grads)
+    return loss, aux
+
+
+@nnx.jit
+def g_step(gen, disc, opt_g, z):
+    """Update the generator with the non-saturating loss: make fakes look real.
+
+    ``disc`` is passed as a (non-differentiated) argument so its spectral-norm
+    layers stay at the transform's trace level; ``value_and_grad`` differentiates
+    argnums=0 only, so no discriminator gradients are produced.
+    """
+
+    def loss_fn(gen, disc):
+        fake = gen(z)
+        # Discriminator is frozen here; don't update its spectral-norm stats.
+        fake_logits = disc(fake, train=False)
+        loss = bce_loss(fake_logits, jnp.ones_like(fake_logits))
+        return loss, fake_logits
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(gen, disc)
+    opt_g.update(gen, grads)
+    return loss, aux
+
+
+# ==== TRAIN LOOP ====
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", "2"))
+    batch = int(os.environ.get("BATCH", "64"))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+    z_dim = 64
+
+    rngs = nnx.Rngs(0)
+    gen = Generator(z_dim=z_dim, rngs=rngs)
+    disc = Discriminator(rngs=rngs)
+
+    opt_g = nnx.Optimizer(gen, optax.adam(2e-4, b1=0.5), wrt=nnx.Param)
+    opt_d = nnx.Optimizer(disc, optax.adam(2e-4, b1=0.5), wrt=nnx.Param)
+
+    data = make_dataset(synthetic=synthetic)
+    n = data.shape[0]
+    key = jax.random.PRNGKey(42)
+
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.fold_in(key, epoch), n)
+        for i in range(0, n - batch + 1, batch):
+            real = data[perm[i:i + batch]]
+            key, kd, kg = jax.random.split(key, 3)
+            d_loss, _ = d_step(gen, disc, opt_d, real, sample_z(kd, batch, z_dim))
+            g_loss, _ = g_step(gen, disc, opt_g, sample_z(kg, batch, z_dim))
+        print(f"epoch {epoch}: d_loss={float(d_loss):.4f}  g_loss={float(g_loss):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generative/ddpm.py
+++ b/examples/generative/ddpm.py
@@ -1,0 +1,280 @@
+"""
+Flax NNX: DDPM Diffusion Model on MNIST
+=======================================
+A minimal denoising diffusion probabilistic model (DDPM): a small
+time-conditioned U-Net learns to predict the noise added at each forward
+step, then iteratively denoises pure Gaussian noise into images.
+
+Run: python generative/ddpm.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import create_optimizer, compute_mse_loss
+
+
+# Default number of diffusion timesteps (kept small so the whole thing is
+# CPU-friendly). Override via the T env var in main().
+DEFAULT_T = 200
+
+
+# ==== NOISE SCHEDULE ====
+
+class DiffusionSchedule:
+    """Linear-beta noise schedule + closed-form forward process q(x_t | x_0).
+
+    This is a plain Python container of precomputed constants (NOT an
+    nnx.Module), so it never shows up in the model's trainable state.
+    """
+
+    def __init__(self, T: int = DEFAULT_T, beta_start: float = 1e-4,
+                 beta_end: float = 0.02):
+        self.T = T
+        betas = jnp.linspace(beta_start, beta_end, T)
+        self.betas = betas
+        self.alphas = 1.0 - betas
+        self.alphas_cumprod = jnp.cumprod(self.alphas)          # \bar{alpha}_t
+        self.sqrt_acp = jnp.sqrt(self.alphas_cumprod)           # sqrt(\bar{alpha}_t)
+        self.sqrt_one_minus_acp = jnp.sqrt(1.0 - self.alphas_cumprod)
+
+    def q_sample(self, x0, t, eps):
+        """Sample x_t ~ q(x_t | x_0) = sqrt(acp)*x_0 + sqrt(1-acp)*eps."""
+        a = self.sqrt_acp[t][:, None, None, None]
+        b = self.sqrt_one_minus_acp[t][:, None, None, None]
+        return a * x0 + b * eps
+
+
+# ==== MODEL ====
+
+class ConvBlock(nnx.Module):
+    """Conv -> GroupNorm -> (+ time embedding) -> SiLU.
+
+    The timestep embedding is projected to the channel dimension and added to
+    every spatial location, which is how the block becomes time-conditioned.
+    The forward pass is wrapped in ``nnx.remat`` to trade compute for memory
+    (gradient checkpointing) on the denoiser blocks.
+    """
+
+    def __init__(self, in_ch: int, out_ch: int, time_dim: int, *,
+                 stride: int = 1, num_groups: int = 8, rngs: nnx.Rngs):
+        self.conv = nnx.Conv(in_ch, out_ch, kernel_size=(3, 3),
+                             strides=(stride, stride), padding='SAME', rngs=rngs)
+        self.norm = nnx.GroupNorm(out_ch, num_groups=num_groups, rngs=rngs)
+        self.time_proj = nnx.Linear(time_dim, out_ch, rngs=rngs)
+
+    @nnx.remat
+    def __call__(self, x, t_emb):
+        h = self.conv(x)
+        h = self.norm(h)
+        h = h + self.time_proj(t_emb)[:, None, None, :]   # broadcast over H, W
+        return nnx.silu(h)
+
+
+class DDPMUNet(nnx.Module):
+    """Compact time-conditioned U-Net that predicts the noise eps.
+
+    One downsample, one upsample, and a single skip connection. Input and
+    output are both (B, 28, 28, 1); the network predicts the noise that was
+    added to produce ``x_t``.
+    """
+
+    def __init__(self, T: int = DEFAULT_T, base: int = 16, time_dim: int = 64,
+                 *, rngs: nnx.Rngs):
+        # Learned timestep embedding: table lookup + small MLP.
+        self.time_embed = nnx.Embed(T, time_dim, rngs=rngs)
+        self.time_mlp1 = nnx.Linear(time_dim, time_dim, rngs=rngs)
+        self.time_mlp2 = nnx.Linear(time_dim, time_dim, rngs=rngs)
+
+        self.in_conv = nnx.Conv(1, base, kernel_size=(3, 3), padding='SAME',
+                                rngs=rngs)                     # (B,28,28,base)
+        self.down = ConvBlock(base, base * 2, time_dim, stride=2, rngs=rngs)   # -> 14x14
+        self.mid = ConvBlock(base * 2, base * 2, time_dim, stride=1, rngs=rngs)
+        self.up = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                    strides=(2, 2), padding='SAME', rngs=rngs)  # -> 28x28
+        # out_block sees the upsampled features concatenated with the skip.
+        self.out_block = ConvBlock(base * 2, base, time_dim, stride=1, rngs=rngs)
+        self.out_conv = nnx.Conv(base, 1, kernel_size=(3, 3), padding='SAME',
+                                 rngs=rngs)                    # (B,28,28,1)
+
+    def __call__(self, x, t):
+        # Timestep embedding shared by every block.
+        te = self.time_embed(t)                # (B, time_dim)
+        te = nnx.silu(self.time_mlp1(te))
+        te = self.time_mlp2(te)
+
+        h0 = nnx.silu(self.in_conv(x))         # (B,28,28,base)  -- skip source
+        h1 = self.down(h0, te)                 # (B,14,14,base*2)
+        h2 = self.mid(h1, te)                  # (B,14,14,base*2)
+        u = nnx.silu(self.up(h2))              # (B,28,28,base)
+        cat = jnp.concatenate([u, h0], axis=-1)  # (B,28,28,base*2)  skip connection
+        h = self.out_block(cat, te)            # (B,28,28,base)
+        return self.out_conv(h)                # (B,28,28,1) predicted noise
+
+
+# ==== FORWARD DIFFUSION / BATCH SAMPLING ====
+
+def sample_batch(schedule: DiffusionSchedule, x0, rng):
+    """Draw a random timestep t and noise eps, then form the noisy input x_t.
+
+    Returns a batch dict consumed directly by ``train_step`` — the schedule is
+    only ever touched here, keeping the jitted train step schedule-free.
+    """
+    key_t, key_e = jax.random.split(rng)
+    t = jax.random.randint(key_t, (x0.shape[0],), 0, schedule.T)
+    eps = jax.random.normal(key_e, x0.shape)
+    x_t = schedule.q_sample(x0, t, eps)
+    return {'x_t': x_t, 't': t, 'eps': eps}
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    """One optimization step of the simplified DDPM objective.
+
+    L = E_{t, x0, eps} || eps - eps_theta(x_t, t) ||^2
+    """
+    def loss_fn(model):
+        pred = model(batch['x_t'], batch['t'])
+        loss = compute_mse_loss(pred, batch['eps'])
+        return loss, pred
+
+    (loss, pred), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, pred
+
+
+# ==== SAMPLING (REVERSE PROCESS) ====
+
+def generate(model, schedule: DiffusionSchedule, num_samples: int, rng):
+    """Ancestral DDPM sampling: start from noise, denoise T steps.
+
+    x_{t-1} = 1/sqrt(alpha_t) * (x_t - beta_t/sqrt(1-acp_t) * eps_theta) + sigma_t z
+
+    The reverse loop is expressed with ``jax.lax.fori_loop`` so the whole
+    trajectory is a single compiled program rather than a Python loop. We
+    ``nnx.split`` the model and thread its (immutable, inference-only) state
+    through the loop carry, then ``nnx.merge`` inside the body — the idiomatic
+    way to call an NNX module from a raw ``lax`` loop without trace-level errors.
+    """
+    graphdef, state = nnx.split(model)
+    T = schedule.T
+    x = jax.random.normal(rng, (num_samples, 28, 28, 1))
+
+    def body(i, carry):
+        x, state, key = carry
+        m = nnx.merge(graphdef, state)                 # rebuild at loop trace level
+        t = T - 1 - i                                  # descend T-1 .. 0
+        key, subkey = jax.random.split(key)
+        t_batch = jnp.full((num_samples,), t, dtype=jnp.int32)
+
+        eps_theta = m(x, t_batch)
+        beta_t = schedule.betas[t]
+        alpha_t = schedule.alphas[t]
+        acp_t = schedule.alphas_cumprod[t]
+
+        coef = beta_t / jnp.sqrt(1.0 - acp_t)
+        mean = (x - coef * eps_theta) / jnp.sqrt(alpha_t)
+
+        noise = jax.random.normal(subkey, x.shape)
+        add_noise = (t > 0).astype(x.dtype)            # no noise on the last step
+        x = mean + add_noise * jnp.sqrt(beta_t) * noise
+        return (x, state, key)
+
+    x, _, _ = jax.lax.fori_loop(0, T, body, (x, state, rng))
+    return x
+
+
+# ==== DATA ====
+
+def make_dataset(n: int = 256, synthetic: bool = True, seed: int = 0):
+    """Return (n, 28, 28, 1) images scaled to [-1, 1].
+
+    Synthetic default: random Gaussian blobs (a simple but genuine image
+    distribution the model can learn to denoise). Real MNIST is loaded via
+    tfds only when synthetic=False.
+    """
+    if synthetic:
+        key = jax.random.PRNGKey(seed)
+        k1, k2 = jax.random.split(key)
+        grid = jnp.linspace(-1.0, 1.0, 28)
+        gx, gy = jnp.meshgrid(grid, grid)                 # (28,28)
+        centers = jax.random.uniform(k1, (n, 2), minval=-0.5, maxval=0.5)
+        widths = jax.random.uniform(k2, (n, 1), minval=0.15, maxval=0.35)
+        cx = centers[:, 0].reshape(n, 1, 1)
+        cy = centers[:, 1].reshape(n, 1, 1)
+        w = widths.reshape(n, 1, 1)
+        dist2 = (gx[None] - cx) ** 2 + (gy[None] - cy) ** 2   # (n,28,28)
+        img = jnp.exp(-dist2 / (2.0 * w ** 2))                # (n,28,28) in [0,1]
+        img = img * 2.0 - 1.0                                 # -> [-1,1]
+        return img[..., None]
+
+    # Real MNIST (opt-in): scale [0,255] -> [-1,1].
+    import tensorflow_datasets as tfds
+    import tensorflow as tf
+    tf.config.set_visible_devices([], 'GPU')
+    ds = tfds.load('mnist', split=f'train[:{n}]', as_supervised=True)
+    imgs = jnp.stack([jnp.asarray(img) for img, _ in tfds.as_numpy(ds)])
+    imgs = imgs.astype(jnp.float32) / 255.0 * 2.0 - 1.0
+    if imgs.ndim == 3:
+        imgs = imgs[..., None]
+    return imgs
+
+
+# ==== MAIN ====
+
+def main():
+    # Run-scale knobs (small CPU-friendly defaults; default to synthetic data).
+    epochs = int(os.environ.get('EPOCHS', 3))
+    batch = int(os.environ.get('BATCH', 32))
+    T = int(os.environ.get('T', DEFAULT_T))
+    synthetic = os.environ.get('SYNTHETIC', '1') != '0'
+    n_data = int(os.environ.get('N_DATA', 256))
+
+    print("=" * 60)
+    print("DDPM diffusion model on MNIST (Flax NNX)")
+    print("=" * 60)
+    print(f"  epochs={epochs}  batch={batch}  T={T}  synthetic={synthetic}")
+
+    schedule = DiffusionSchedule(T=T)
+    x0 = make_dataset(n=n_data, synthetic=synthetic)
+    print(f"  dataset: {x0.shape}  range=[{float(x0.min()):.2f}, {float(x0.max()):.2f}]")
+
+    rngs = nnx.Rngs(0)
+    model = DDPMUNet(T=T, rngs=rngs)
+    optimizer = create_optimizer(model, 2e-3, optimizer_name='adam')
+
+    n_params = sum(p.size for p in jax.tree.leaves(nnx.state(model, nnx.Param)))
+    print(f"  parameters: {n_params:,}\n")
+
+    key = jax.random.PRNGKey(1)
+    steps_per_epoch = max(1, x0.shape[0] // batch)
+    for epoch in range(1, epochs + 1):
+        key, perm_key = jax.random.split(key)
+        perm = jax.random.permutation(perm_key, x0.shape[0])
+        running = 0.0
+        for s in range(steps_per_epoch):
+            idx = perm[s * batch:(s + 1) * batch]
+            key, bkey = jax.random.split(key)
+            b = sample_batch(schedule, x0[idx], bkey)
+            loss, _ = train_step(model, optimizer, b)
+            running += float(loss)
+        print(f"  epoch {epoch:2d}/{epochs} | noise-MSE: {running / steps_per_epoch:.4f}")
+
+    # Generate a handful of samples from pure noise.
+    key, gkey = jax.random.split(key)
+    samples = generate(model, schedule, 4, gkey)
+    print(f"\n  generated samples: {samples.shape} "
+          f"range=[{float(samples.min()):.2f}, {float(samples.max()):.2f}]")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generative/normalizing_flows.py
+++ b/examples/generative/normalizing_flows.py
@@ -1,0 +1,196 @@
+"""
+RealNVP Normalizing Flow on Two Moons
+=====================================
+Learn an exact, invertible density with Flax NNX. A stack of affine coupling
+layers maps the two-moons data distribution to a standard-normal base; the
+tractable log-determinant lets us train by exact maximum likelihood and both
+sample (base -> data) and score (data -> base).
+
+Run: python generative/normalizing_flows.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.models import MLP
+
+
+# ==== AFFINE COUPLING LAYER ====
+
+class AffineCoupling(nnx.Module):
+    """RealNVP affine coupling layer.
+
+    A binary `parity` mask keeps half the dimensions unchanged and uses them to
+    predict a per-dimension scale ``s`` and shift ``t`` for the other half:
+
+        forward:  z = x_kept + (1-mask) * (x * exp(s) + t),   logdet = sum(s)
+        inverse:  x = z_kept + (1-mask) * (z - t) * exp(-s)
+
+    The masked (kept) half passes through unchanged, so the Jacobian is
+    triangular and its log-determinant is just ``sum(s)`` over transformed dims.
+    Alternating `parity` between stacked layers lets every dimension be
+    transformed. ``s`` is squashed with ``tanh`` to keep the scale bounded.
+    """
+
+    def __init__(self, dim: int, hidden: int, parity: int, *, rngs: nnx.Rngs):
+        self.dim = dim
+        self.parity = parity
+        # Conditioner: (kept dims) -> concat[s_raw, t], each of size `dim`.
+        self.net = MLP(dim, hidden, 2 * dim, n_layers=2, rngs=rngs, activation="gelu")
+
+    def _mask(self):
+        # 1.0 where a dim is kept (conditions), 0.0 where it is transformed.
+        return (jnp.arange(self.dim) % 2 == self.parity).astype(jnp.float32)
+
+    def _s_t(self, u, mask):
+        # Condition only on the kept dims; zero out the rest of the input.
+        s_raw, t = jnp.split(self.net(u * mask), 2, axis=-1)
+        s = jnp.tanh(s_raw) * (1.0 - mask)   # scale only on transformed dims
+        t = t * (1.0 - mask)                 # shift only on transformed dims
+        return s, t
+
+    def forward(self, x):
+        """Data -> latent, returning (z, logdet) with logdet of shape (B,)."""
+        mask = self._mask()
+        s, t = self._s_t(x, mask)
+        z = x * mask + (1.0 - mask) * (x * jnp.exp(s) + t)
+        logdet = jnp.sum(s, axis=-1)
+        return z, logdet
+
+    def inverse(self, z):
+        """Latent -> data (exact inverse of `forward`)."""
+        mask = self._mask()
+        s, t = self._s_t(z, mask)  # kept dims are identical to x, so s,t match
+        x = z * mask + (1.0 - mask) * (z - t) * jnp.exp(-s)
+        return x
+
+
+# ==== REALNVP: A STACK OF COUPLING LAYERS ====
+
+class RealNVP(nnx.Module):
+    """A normalizing flow: composition of alternating affine coupling layers."""
+
+    def __init__(self, dim: int = 2, hidden: int = 64, n_layers: int = 6, *, rngs: nnx.Rngs):
+        self.dim = dim
+        # Plain lists of submodules MUST be wrapped in nnx.List on Flax 0.12.
+        self.layers = nnx.List([
+            AffineCoupling(dim, hidden, parity=i % 2, rngs=rngs)
+            for i in range(n_layers)
+        ])
+
+    def forward(self, x):
+        """Data -> base z, accumulating the total log|det dz/dx|."""
+        logdet = jnp.zeros(x.shape[0])
+        z = x
+        for layer in self.layers:
+            z, ld = layer.forward(z)
+            logdet = logdet + ld
+        return z, logdet
+
+    def inverse(self, z):
+        """Base z -> data x, applying the layers in reverse order."""
+        x = z
+        for i in range(len(self.layers) - 1, -1, -1):
+            x = self.layers[i].inverse(x)
+        return x
+
+    def log_prob(self, x):
+        """Exact log-density via change of variables under a N(0, I) base."""
+        z, logdet = self.forward(x)
+        # log N(z; 0, I) = -0.5 * ||z||^2 - 0.5 * d * log(2*pi)
+        logpz = -0.5 * jnp.sum(z ** 2, axis=-1) - 0.5 * self.dim * jnp.log(2.0 * jnp.pi)
+        return logpz + logdet
+
+    def sample(self, n: int, seed: int = 0):
+        """Draw z ~ N(0, I) and push it through the inverse flow to data space."""
+        z = jax.random.normal(jax.random.key(seed), (n, self.dim))
+        return self.inverse(z)
+
+
+# ==== LOSS: NEGATIVE LOG-LIKELIHOOD ====
+
+def nll_loss(model: RealNVP, x):
+    """Exact maximum-likelihood objective: mean negative log-density."""
+    return -model.log_prob(x).mean()
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model: RealNVP, optimizer: nnx.Optimizer, batch):
+    def loss_fn(model):
+        nll = nll_loss(model, batch)
+        return nll, nll  # aux = nll (scalar) for logging
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, aux
+
+
+# ==== DATA: SYNTHETIC TWO MOONS (NO SKLEARN) ====
+
+def make_two_moons(n: int = 1024, noise: float = 0.1, seed: int = 0):
+    """Sample the two-moons distribution as two noisy half circles.
+
+    Fully offline: outer moon is the upper half circle, inner moon is a shifted
+    lower half circle. Returns standardized points of shape (n, 2) so the
+    N(0, I) base is a good match.
+    """
+    key = jax.random.key(seed)
+    k1, k2, k3 = jax.random.split(key, 3)
+    n_out = n // 2
+    n_in = n - n_out
+
+    t_out = jnp.pi * jax.random.uniform(k1, (n_out,))
+    outer = jnp.stack([jnp.cos(t_out), jnp.sin(t_out)], axis=1)
+
+    t_in = jnp.pi * jax.random.uniform(k2, (n_in,))
+    inner = jnp.stack([1.0 - jnp.cos(t_in), 1.0 - jnp.sin(t_in) - 0.5], axis=1)
+
+    x = jnp.concatenate([outer, inner], axis=0)
+    x = x + noise * jax.random.normal(k3, x.shape)
+    # Standardize to zero mean / unit variance per dim.
+    x = (x - x.mean(0)) / (x.std(0) + 1e-6)
+    return x
+
+
+# ==== MAIN ====
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 8))
+    batch = int(os.environ.get("BATCH", 128))
+    n = int(os.environ.get("SYNTHETIC", 1024))  # dataset size (synthetic by default)
+
+    rngs = nnx.Rngs(0)
+    model = RealNVP(dim=2, hidden=64, n_layers=6, rngs=rngs)
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    data = make_two_moons(n=n, seed=0)
+
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.key(epoch), n)
+        data = data[perm]
+        total, steps = 0.0, 0
+        for i in range(0, n, batch):
+            xb = data[i:i + batch]
+            loss, _ = train_step(model, optimizer, xb)
+            total += float(loss)
+            steps += 1
+        print(f"epoch {epoch + 1}/{epochs}  nll {total / steps:.4f}")
+
+    samples = model.sample(256, seed=0)
+    z, _ = model.forward(data[:256])
+    print(f"samples: {samples.shape}  latent: {z.shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generative/vae.py
+++ b/examples/generative/vae.py
@@ -1,0 +1,154 @@
+"""
+Variational Autoencoder (VAE) on MNIST
+======================================
+Learn a probabilistic latent space with Flax NNX: an encoder outputs a Gaussian
+q(z|x), we sample z via the reparameterization trick, and a decoder reconstructs
+the image. Trained by maximizing the ELBO (reconstruction - KL). Explicit NNX RNG
+streams (params vs. noise) keep parameter init and latent sampling independent.
+
+Run: python generative/vae.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.models import ConvEncoder, ConvDecoder
+from shared.training_utils import bce_loss, kl_divergence
+
+
+# ==== ENCODER: q(z|x) = N(mu, diag(exp(logvar))) ====
+
+class Encoder(nnx.Module):
+    """Conv downsampler -> two heads producing mu and logvar of q(z|x)."""
+
+    def __init__(self, latent_dim: int, base: int = 16, *, rngs: nnx.Rngs):
+        # Shared conv body: (B, 28, 28, 1) -> (B, 7, 7, base*2)
+        self.body = ConvEncoder(1, base, rngs=rngs)
+        feat = base * 2 * 7 * 7  # 32 * 7 * 7 = 1568 for base=16
+        self.mu = nnx.Linear(feat, latent_dim, rngs=rngs)
+        self.logvar = nnx.Linear(feat, latent_dim, rngs=rngs)
+
+    def __call__(self, x):
+        h = self.body(x)
+        h = h.reshape(h.shape[0], -1)  # flatten
+        return self.mu(h), self.logvar(h)
+
+
+# ==== VAE: encoder + reparameterization + decoder ====
+
+class VAE(nnx.Module):
+    """Full VAE. The `noise` RNG stream drives latent sampling, separate from
+    the `params` stream used to initialize weights."""
+
+    def __init__(self, latent_dim: int = 16, base: int = 16, *, rngs: nnx.Rngs):
+        self.latent_dim = latent_dim
+        self.encoder = Encoder(latent_dim, base, rngs=rngs)
+        # Shared decoder: latent -> (B, 28, 28, 1) LOGITS
+        self.decoder = ConvDecoder(latent_dim, base, 1, rngs=rngs)
+        self.rngs = rngs
+
+    def __call__(self, x):
+        mu, logvar = self.encoder(x)
+        std = jnp.exp(0.5 * logvar)
+        # Reparameterization trick: z = mu + std * eps, eps ~ N(0, I)
+        eps = jax.random.normal(self.rngs.noise(), mu.shape)
+        z = mu + std * eps
+        return self.decoder(z), mu, logvar  # logits, mu, logvar
+
+    def sample(self, n: int, seed: int = 0):
+        """Draw z ~ N(0, I) and decode to images in [0, 1]."""
+        z = jax.random.normal(jax.random.key(seed), (n, self.latent_dim))
+        return nnx.sigmoid(self.decoder(z))
+
+
+# ==== LOSS: negative ELBO = reconstruction + KL ====
+
+def vae_loss(model: VAE, x):
+    logits, mu, logvar = model(x)
+    recon = bce_loss(logits, x)          # -E_q[log p(x|z)] (sigmoid BCE, summed)
+    kl = kl_divergence(mu, logvar)        # D_KL(q(z|x) || N(0, I))
+    return recon + kl, (recon, kl)
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model: VAE, optimizer: nnx.Optimizer, batch):
+    def loss_fn(model):
+        return vae_loss(model, batch)
+
+    (loss, (recon, kl)), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, (recon, kl)
+
+
+# ==== DATA ====
+
+def make_dataset(synthetic: bool = True, n: int = 512, seed: int = 0):
+    """Return images of shape (N, 28, 28, 1) with values in [0, 1].
+
+    Synthetic default draws smooth Gaussian blobs (offline, learnable structure).
+    Set SYNTHETIC=0 to load real MNIST via tfds.
+    """
+    if synthetic:
+        key = jax.random.key(seed)
+        cy = jax.random.uniform(key, (n,), minval=8.0, maxval=20.0)
+        cx = jax.random.uniform(jax.random.fold_in(key, 1), (n,), minval=8.0, maxval=20.0)
+        ys, xs = jnp.mgrid[0:28, 0:28]
+        ys = ys.astype(jnp.float32)
+        xs = xs.astype(jnp.float32)
+        d2 = (ys[None] - cy[:, None, None]) ** 2 + (xs[None] - cx[:, None, None]) ** 2
+        imgs = jnp.exp(-d2 / (2.0 * 4.0 ** 2))  # (N, 28, 28) in (0, 1]
+        return imgs[..., None]
+
+    import tensorflow_datasets as tfds
+    ds = tfds.load("mnist", split="train", as_supervised=True)
+    imgs = jnp.stack([jnp.asarray(img) for img, _ in tfds.as_numpy(ds.take(n))])
+    imgs = imgs.astype(jnp.float32) / 255.0
+    if imgs.ndim == 3:
+        imgs = imgs[..., None]
+    return imgs
+
+
+# ==== MAIN ====
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 3))
+    batch = int(os.environ.get("BATCH", 64))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+
+    # Two independent RNG streams: params (init) and noise (latent sampling).
+    rngs = nnx.Rngs(params=0, noise=1)
+    model = VAE(latent_dim=16, rngs=rngs)
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    data = make_dataset(synthetic=synthetic)
+    n = data.shape[0]
+
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.key(epoch), n)
+        data = data[perm]
+        total, steps = 0.0, 0
+        for i in range(0, n, batch):
+            xb = data[i:i + batch]
+            loss, (recon, kl) = train_step(model, optimizer, xb)
+            total += float(loss)
+            steps += 1
+        print(f"epoch {epoch + 1}/{epochs}  ELBO loss {total / steps:.2f}  "
+              f"(recon {float(recon):.2f}  kl {float(kl):.2f})")
+
+    samples = model.sample(8, seed=0)
+    print(f"generated samples: {samples.shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/index.py
+++ b/examples/index.py
@@ -166,6 +166,74 @@ EXAMPLES = {
                 "concepts": ["imagenet", "resnet", "large-scale training"]
             }
         ]
+    },
+    "Generative": {
+        "description": "Generative models — learn to sample data, not just classify it",
+        "examples": [
+            {
+                "name": "Autoencoder (+ Denoising)",
+                "file": "generative/autoencoder.py",
+                "description": "Compress and reconstruct images through a bottleneck",
+                "concepts": ["nnx.ConvTranspose", "ConvEncoder/ConvDecoder", "reconstruction loss"]
+            },
+            {
+                "name": "Variational Autoencoder (VAE)",
+                "file": "generative/vae.py",
+                "description": "Probabilistic latent + reparameterization; sample new digits",
+                "concepts": ["reparameterization", "ELBO", "nnx.Rngs noise stream"]
+            },
+            {
+                "name": "DCGAN",
+                "file": "generative/dcgan.py",
+                "description": "Generator vs discriminator with two optimizers + spectral norm",
+                "concepts": ["adversarial training", "nnx.SpectralNorm", "two optimizers"]
+            },
+            {
+                "name": "Diffusion Model (DDPM)",
+                "file": "generative/ddpm.py",
+                "description": "Iterative denoising with a small time-conditioned U-Net",
+                "concepts": ["diffusion", "nnx.Embed timestep", "nnx.GroupNorm", "sampling loop"]
+            }
+        ]
+    },
+    "Sequence": {
+        "description": "Sequence models — recurrence and order",
+        "examples": [
+            {
+                "name": "Recurrent Networks (RNN/LSTM/GRU)",
+                "file": "sequence/rnn_cells.py",
+                "description": "The nnx.RNN API family + manual nnx.scan on a parity task",
+                "concepts": ["nnx.RNN", "nnx.LSTMCell/GRUCell", "nnx.Bidirectional", "nnx.scan"]
+            }
+        ]
+    },
+    "Scientific": {
+        "description": "Graphs, scientific ML, and structured data",
+        "examples": [
+            {
+                "name": "Graph Neural Network (GCN)",
+                "file": "scientific/gcn_karate.py",
+                "description": "Semi-supervised node classification on Zachary's Karate Club",
+                "concepts": ["message passing", "normalized adjacency", "nnx.Einsum"]
+            },
+            {
+                "name": "Physics-Informed NN (PINN)",
+                "file": "scientific/pinn_oscillator.py",
+                "description": "Solve an ODE by differentiating the model output w.r.t. its input",
+                "concepts": ["jax.grad on input", "residual loss", "scientific ML"]
+            }
+        ]
+    },
+    "Adaptation": {
+        "description": "Fine-tuning and adaptation of existing models",
+        "examples": [
+            {
+                "name": "LoRA Fine-Tuning",
+                "file": "adaptation/lora_finetuning.py",
+                "description": "Freeze a model, train only low-rank adapters",
+                "concepts": ["nnx.LoRALinear", "nnx.Optimizer(wrt=nnx.LoRAParam)", "nnx.DiffState"]
+            }
+        ]
     }
 }
 

--- a/examples/index.py
+++ b/examples/index.py
@@ -124,6 +124,24 @@ EXAMPLES = {
                 "file": "advanced/dqn_reinforcement_learning.py",
                 "description": "Deep Q-Network reinforcement learning",
                 "concepts": ["dqn", "reinforcement learning", "replay buffer"]
+            },
+            {
+                "name": "Metric Learning (Siamese/Triplet)",
+                "file": "advanced/metric_learning.py",
+                "description": "Learn an embedding where same-class inputs cluster (triplet loss)",
+                "concepts": ["metric learning", "triplet loss", "siamese", "mining"]
+            },
+            {
+                "name": "Interpretability & Saliency",
+                "file": "advanced/interpretability.py",
+                "description": "Saliency, Integrated Gradients, and Grad-CAM via jax.grad on inputs",
+                "concepts": ["saliency", "integrated gradients", "grad-cam", "attribution"]
+            },
+            {
+                "name": "Uncertainty Estimation",
+                "file": "advanced/uncertainty.py",
+                "description": "MC-dropout and deep ensembles for predictive uncertainty",
+                "concepts": ["mc-dropout", "deep ensembles", "nnx.vmap", "calibration"]
             }
         ]
     },
@@ -193,6 +211,12 @@ EXAMPLES = {
                 "file": "generative/ddpm.py",
                 "description": "Iterative denoising with a small time-conditioned U-Net",
                 "concepts": ["diffusion", "nnx.Embed timestep", "nnx.GroupNorm", "sampling loop"]
+            },
+            {
+                "name": "Normalizing Flows (RealNVP)",
+                "file": "generative/normalizing_flows.py",
+                "description": "Invertible network with exact likelihood via change of variables",
+                "concepts": ["RealNVP", "affine coupling", "log-det Jacobian"]
             }
         ]
     },
@@ -204,6 +228,24 @@ EXAMPLES = {
                 "file": "sequence/rnn_cells.py",
                 "description": "The nnx.RNN API family + manual nnx.scan on a parity task",
                 "concepts": ["nnx.RNN", "nnx.LSTMCell/GRUCell", "nnx.Bidirectional", "nnx.scan"]
+            },
+            {
+                "name": "Seq2Seq with Attention",
+                "file": "sequence/seq2seq_attention.py",
+                "description": "Encoder-decoder with cross-attention on a copy/reverse task",
+                "concepts": ["seq2seq", "cross-attention", "nnx.MultiHeadAttention", "teacher forcing"]
+            },
+            {
+                "name": "Time-Series Forecasting",
+                "file": "sequence/time_series.py",
+                "description": "LSTM multi-step forecasting on synthetic sinusoids",
+                "concepts": ["forecasting", "sliding windows", "nnx.LSTMCell"]
+            },
+            {
+                "name": "Word2Vec (skip-gram)",
+                "file": "sequence/word2vec.py",
+                "description": "Learn word embeddings with skip-gram + negative sampling",
+                "concepts": ["nnx.Embed", "negative sampling", "embeddings"]
             }
         ]
     },
@@ -221,6 +263,41 @@ EXAMPLES = {
                 "file": "scientific/pinn_oscillator.py",
                 "description": "Solve an ODE by differentiating the model output w.r.t. its input",
                 "concepts": ["jax.grad on input", "residual loss", "scientific ML"]
+            },
+            {
+                "name": "Neural ODE",
+                "file": "scientific/neural_ode.py",
+                "description": "Continuous-depth model integrated through a differentiable RK4 solver",
+                "concepts": ["neural ODE", "jax.lax.scan solver", "continuous depth"]
+            },
+            {
+                "name": "Tabular Deep Learning",
+                "file": "scientific/tabular_dnn.py",
+                "description": "MLP with categorical embeddings for structured data",
+                "concepts": ["nnx.Embed categoricals", "tabular", "regression/classification"]
+            },
+            {
+                "name": "Mixture of Experts (MoE)",
+                "file": "scientific/moe.py",
+                "description": "Sparse top-k expert routing with a load-balancing loss",
+                "concepts": ["MoE", "top-k gating", "load balancing", "nnx.Einsum"]
+            }
+        ]
+    },
+    "Vision": {
+        "description": "Vision beyond CNNs — attention and dense prediction",
+        "examples": [
+            {
+                "name": "Vision Transformer (ViT)",
+                "file": "vision/vit.py",
+                "description": "Patch embedding + transformer encoder for image classification",
+                "concepts": ["ViT", "patch embedding", "nnx.MultiHeadAttention", "CLS token"]
+            },
+            {
+                "name": "U-Net Segmentation",
+                "file": "vision/unet_segmentation.py",
+                "description": "Encoder-decoder with skip connections for per-pixel masks",
+                "concepts": ["U-Net", "nnx.ConvTranspose", "skip connections", "segmentation"]
             }
         ]
     },
@@ -232,6 +309,12 @@ EXAMPLES = {
                 "file": "adaptation/lora_finetuning.py",
                 "description": "Freeze a model, train only low-rank adapters",
                 "concepts": ["nnx.LoRALinear", "nnx.Optimizer(wrt=nnx.LoRAParam)", "nnx.DiffState"]
+            },
+            {
+                "name": "CLIP (toy)",
+                "file": "adaptation/clip_toy.py",
+                "description": "Align image and text encoders with a symmetric contrastive loss",
+                "concepts": ["CLIP", "cross-modal", "contrastive", "dual encoders"]
             }
         ]
     }

--- a/examples/scientific/__init__.py
+++ b/examples/scientific/__init__.py
@@ -1,0 +1,1 @@
+"""scientific examples."""

--- a/examples/scientific/gcn_karate.py
+++ b/examples/scientific/gcn_karate.py
@@ -1,0 +1,252 @@
+"""
+Graph Convolutional Network on Zachary's Karate Club
+====================================================
+A two-layer GCN that classifies the 34 members of Zachary's Karate Club into
+their two real-world factions from only *two* labeled nodes (semi-supervised
+node classification) using symmetric-normalized neighborhood aggregation.
+
+Run: python scientific/gcn_karate.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared.training_utils import compute_accuracy
+
+# ============================================================================
+# THE GRAPH: Zachary's Karate Club (34 nodes, 78 undirected edges)
+# ============================================================================
+# The classic social-network benchmark. A karate club split into two factions
+# after a dispute between the instructor "Mr. Hi" (node 0) and the club
+# administrator "Officer" (node 33). We know the full ground-truth split, but
+# we only *reveal* those two anchor labels to the model.
+
+NUM_NODES = 34
+NUM_CLASSES = 2
+
+# Standard 0-indexed edge list (matches networkx.karate_club_graph()).
+EDGES = [
+    (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6), (0, 7), (0, 8),
+    (0, 10), (0, 11), (0, 12), (0, 13), (0, 17), (0, 19), (0, 21), (0, 31),
+    (1, 2), (1, 3), (1, 7), (1, 13), (1, 17), (1, 19), (1, 21), (1, 30),
+    (2, 3), (2, 7), (2, 8), (2, 9), (2, 13), (2, 27), (2, 28), (2, 32),
+    (3, 7), (3, 12), (3, 13),
+    (4, 6), (4, 10),
+    (5, 6), (5, 10), (5, 16),
+    (6, 16),
+    (8, 30), (8, 32), (8, 33),
+    (9, 33),
+    (13, 33),
+    (14, 32), (14, 33),
+    (15, 32), (15, 33),
+    (18, 32), (18, 33),
+    (19, 33),
+    (20, 32), (20, 33),
+    (22, 32), (22, 33),
+    (23, 25), (23, 27), (23, 29), (23, 32), (23, 33),
+    (24, 25), (24, 27), (24, 31),
+    (25, 31),
+    (26, 29), (26, 33),
+    (27, 33),
+    (28, 31), (28, 33),
+    (29, 32), (29, 33),
+    (30, 32), (30, 33),
+    (31, 32), (31, 33),
+    (32, 33),
+]
+
+# Ground-truth community for every node (0 = Mr. Hi faction, 1 = Officer
+# faction). Used ONLY for evaluation, never for training.
+TRUE_LABELS = jnp.array([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+], dtype=jnp.int32)
+
+# The two semi-supervised anchors: the two faction leaders.
+ANCHOR_NODES = (0, 33)
+
+
+# ============================================================================
+# ADJACENCY + SYMMETRIC NORMALIZATION
+# ============================================================================
+
+def normalize_adjacency(edges, num_nodes: int) -> jax.Array:
+    r"""Build the symmetric-normalized adjacency with self-loops.
+
+    Computes  \hat A = D^{-1/2} (A + I) D^{-1/2}, where A is the binary
+    adjacency of the undirected graph and D is the degree matrix of A + I.
+    """
+    a = jnp.zeros((num_nodes, num_nodes), dtype=jnp.float32)
+    src = jnp.array([e[0] for e in edges])
+    dst = jnp.array([e[1] for e in edges])
+    a = a.at[src, dst].set(1.0)
+    a = a.at[dst, src].set(1.0)          # undirected -> symmetric
+
+    a = a + jnp.eye(num_nodes)           # add self-loops (A + I)
+    deg = a.sum(axis=1)                  # row degrees of (A + I)
+    d_inv_sqrt = jnp.power(deg, -0.5)
+    d_inv_sqrt = jnp.diag(d_inv_sqrt)
+    return d_inv_sqrt @ a @ d_inv_sqrt   # D^{-1/2} (A + I) D^{-1/2}
+
+
+def make_dataset(synthetic: bool = True):
+    """Return the karate-club graph as tiny jnp arrays (fully offline).
+
+    The graph itself is the dataset, so `synthetic=True` (the default) simply
+    builds it from the hardcoded edge list. `synthetic=False` rebuilds the same
+    graph from networkx to cross-check, if that optional dependency is present.
+    """
+    edges = EDGES
+    labels = TRUE_LABELS
+    if not synthetic:
+        try:
+            import networkx as nx
+
+            g = nx.karate_club_graph()
+            edges = list(g.edges())
+            labels = jnp.array(
+                [0 if g.nodes[i]["club"] == "Mr. Hi" else 1 for i in g.nodes()],
+                dtype=jnp.int32,
+            )
+        except Exception as exc:  # pragma: no cover - offline fallback
+            print(f"[make_dataset] networkx unavailable ({exc}); using hardcoded graph.")
+
+    a_hat = normalize_adjacency(edges, NUM_NODES)
+
+    # Identity (one-hot node-id) features: each node is its own basis vector.
+    features = jnp.eye(NUM_NODES, dtype=jnp.float32)
+    node_ids = jnp.arange(NUM_NODES, dtype=jnp.int32)
+
+    # Semi-supervised mask: 1.0 only on the two anchor nodes.
+    train_mask = jnp.zeros((NUM_NODES,), dtype=jnp.float32)
+    train_mask = train_mask.at[jnp.array(ANCHOR_NODES)].set(1.0)
+
+    return {
+        "a_hat": a_hat,
+        "features": features,
+        "node_ids": node_ids,
+        "labels": labels,
+        "train_mask": train_mask,
+    }
+
+
+# ============================================================================
+# MODEL: two-layer Graph Convolutional Network
+# ============================================================================
+
+class GCNLayer(nnx.Module):
+    r"""One graph-convolution layer:  H' = \hat A H W.
+
+    `nnx.Linear` (no bias) supplies the learnable weight W; the fixed
+    normalized adjacency \hat A does the neighborhood aggregation via an
+    einsum (a plain, parameter-free matmul over the node axis).
+    """
+
+    def __init__(self, in_features: int, out_features: int, *, rngs: nnx.Rngs):
+        self.linear = nnx.Linear(in_features, out_features, use_bias=False, rngs=rngs)
+
+    def __call__(self, a_hat: jax.Array, h: jax.Array) -> jax.Array:
+        h = self.linear(h)                          # H W    -> (N, out)
+        h = jnp.einsum("ij,jf->if", a_hat, h)       # \hat A (H W) -> (N, out)
+        return h
+
+
+class GCN(nnx.Module):
+    """Two GCN layers mapping node features to class logits."""
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        num_classes: int,
+        *,
+        use_embedding: bool = False,
+        num_nodes: int = NUM_NODES,
+        rngs: nnx.Rngs,
+    ):
+        self.use_embedding = use_embedding
+        if use_embedding:
+            # Learn a dense feature per node instead of using one-hot inputs.
+            self.embed = nnx.Embed(num_nodes, in_features, rngs=rngs)
+        self.gcn1 = GCNLayer(in_features, hidden_features, rngs=rngs)
+        self.gcn2 = GCNLayer(hidden_features, num_classes, rngs=rngs)
+
+    def __call__(self, a_hat, features=None, node_ids=None):
+        h = self.embed(node_ids) if self.use_embedding else features
+        h = nnx.relu(self.gcn1(a_hat, h))           # (N, hidden)
+        logits = self.gcn2(a_hat, h)                # (N, num_classes)
+        return logits
+
+
+def create_model(rngs: nnx.Rngs, *, use_embedding: bool = False, hidden_features: int = 16):
+    """Build a karate-club GCN (34 one-hot inputs -> hidden -> 2 classes)."""
+    in_features = 8 if use_embedding else NUM_NODES
+    return GCN(
+        in_features=in_features,
+        hidden_features=hidden_features,
+        num_classes=NUM_CLASSES,
+        use_embedding=use_embedding,
+        rngs=rngs,
+    )
+
+
+# ============================================================================
+# LOSS + TRAIN STEP
+# ============================================================================
+
+def masked_cross_entropy(logits, labels, mask):
+    """Cross-entropy averaged over the labeled (masked) nodes only."""
+    ce = optax.softmax_cross_entropy_with_integer_labels(logits, labels)
+    return (ce * mask).sum() / mask.sum()
+
+
+@nnx.jit
+def train_step(model: GCN, optimizer: nnx.Optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["a_hat"], features=batch["features"], node_ids=batch["node_ids"])
+        loss = masked_cross_entropy(logits, batch["labels"], batch["train_mask"])
+        acc = compute_accuracy(logits, batch["labels"])   # accuracy over ALL nodes
+        return loss, acc
+
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 200))          # full-batch grad steps
+    _ = int(os.environ.get("BATCH", NUM_NODES))          # single-graph: unused
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+
+    batch = make_dataset(synthetic=synthetic)
+
+    model = create_model(nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+
+    print(f"Training GCN on Zachary's Karate Club for {epochs} steps "
+          f"(labeled anchors: nodes {ANCHOR_NODES[0]} and {ANCHOR_NODES[1]})\n")
+    for step in range(epochs):
+        loss, acc = train_step(model, optimizer, batch)
+        if step % 20 == 0 or step == epochs - 1:
+            print(f"step {step:4d} | masked loss {float(loss):.4f} | full-graph acc {float(acc):.3f}")
+
+    logits = model(batch["a_hat"], features=batch["features"], node_ids=batch["node_ids"])
+    final_acc = float(compute_accuracy(logits, batch["labels"]))
+    print(f"\nFinal full-graph accuracy: {final_acc:.3f} "
+          f"({int(final_acc * NUM_NODES)}/{NUM_NODES} nodes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scientific/moe.py
+++ b/examples/scientific/moe.py
@@ -1,0 +1,195 @@
+"""
+Mixture of Experts (MoE) in Flax NNX
+====================================
+A sparse Mixture-of-Experts layer: N small expert MLPs plus a learnable gate
+that top-k routes each input, combines the chosen experts' outputs, and trains
+against a task loss plus a load-balancing auxiliary loss on synthetic data.
+
+Run: python scientific/moe.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared.models import MLP
+from shared.training_utils import compute_accuracy
+
+# Weight on the load-balancing auxiliary loss (task CE dominates the total).
+AUX_COEF = 0.01
+
+
+# ============================================================================
+# SYNTHETIC DATA: a Gaussian mixture of `n_classes` well-separated blobs
+# ============================================================================
+# Fully offline. Each class is a Gaussian blob around its own random mean, so
+# different regions of input space carry different labels -- exactly the kind of
+# piecewise structure a Mixture of Experts can carve up between specialists.
+
+def make_dataset(n_samples: int, in_features: int, n_classes: int, key):
+    k_mean, k_label, k_noise = jax.random.split(key, 3)
+    means = jax.random.normal(k_mean, (n_classes, in_features)) * 3.0
+    labels = jax.random.randint(k_label, (n_samples,), 0, n_classes)
+    noise = jax.random.normal(k_noise, (n_samples, in_features))
+    x = means[labels] + noise
+    return {"x": x, "y": labels}
+
+
+# ============================================================================
+# THE MoE LAYER: gate + top-k routing + weighted combination + balance loss
+# ============================================================================
+
+class MoELayer(nnx.Module):
+    r"""Sparse Mixture of Experts over a `d_model`-dim token representation.
+
+    A linear gate scores every expert; each token keeps only its top-`k`
+    experts (softmax-weighted), and their outputs are summed. We compute all
+    experts densely and mask by the top-k selection -- simple and fast for the
+    small expert counts used on CPU.
+    """
+
+    def __init__(self, d_model: int, d_hidden: int, n_experts: int, k: int, *, rngs: nnx.Rngs):
+        self.n_experts = n_experts
+        self.k = k
+        # Routing logits: one score per expert. No bias -> pure content routing.
+        self.gate = nnx.Linear(d_model, n_experts, use_bias=False, rngs=rngs)
+        # Experts are independent MLPs (d_model -> d_hidden -> d_model).
+        # MUST be an nnx.List so the submodules register as state on Flax 0.12.
+        self.experts = nnx.List([
+            MLP(d_model, d_hidden, d_model, n_layers=2, rngs=rngs)
+            for _ in range(n_experts)
+        ])
+
+    def __call__(self, x: jax.Array, train: bool = False):
+        # x: (B, d_model)
+        gate_logits = self.gate(x)                              # (B, E)
+        router_probs = jax.nn.softmax(gate_logits, axis=-1)     # (B, E) full softmax
+
+        # --- top-k routing ---
+        top_vals, top_idx = jax.lax.top_k(gate_logits, self.k)  # (B, k), (B, k)
+        top_gates = jax.nn.softmax(top_vals, axis=-1)           # (B, k) combine weights
+        one_hot = jax.nn.one_hot(top_idx, self.n_experts)       # (B, k, E)
+        # Scatter the k combine weights back onto a dense (B, E) gate matrix.
+        dense_gates = jnp.einsum("bk,bke->be", top_gates, one_hot)  # (B, E)
+
+        # --- run every expert, then combine the selected ones ---
+        expert_out = jnp.stack(
+            [expert(x, train=train) for expert in self.experts], axis=1
+        )                                                        # (B, E, d_model)
+        y = jnp.einsum("be,bed->bd", dense_gates, expert_out)    # (B, d_model)
+
+        # --- load-balancing auxiliary loss (Switch-Transformer style) ---
+        # f_i: fraction of the B*k routing slots that landed on expert i.
+        # P_i: mean router probability mass on expert i.
+        selection = one_hot.sum(axis=1)                          # (B, E) in {0,1}
+        f = selection.sum(axis=0) / (x.shape[0] * self.k)        # (E,) sums to 1
+        p = router_probs.mean(axis=0)                            # (E,) sums to 1
+        balance_loss = self.n_experts * jnp.sum(f * p)           # minimized (=1) when uniform
+
+        return y, balance_loss, f
+
+
+# ============================================================================
+# THE CLASSIFIER: stem -> MoE (residual + norm) -> linear head
+# ============================================================================
+
+class MoEClassifier(nnx.Module):
+    """Transformer-FFN-style block: a residual MoE layer feeding a class head."""
+
+    def __init__(
+        self,
+        in_features: int,
+        d_model: int,
+        d_hidden: int,
+        n_experts: int,
+        k: int,
+        n_classes: int,
+        *,
+        rngs: nnx.Rngs,
+    ):
+        self.stem = nnx.Linear(in_features, d_model, rngs=rngs)
+        self.moe = MoELayer(d_model, d_hidden, n_experts, k, rngs=rngs)
+        self.norm = nnx.LayerNorm(d_model, rngs=rngs)
+        self.head = nnx.Linear(d_model, n_classes, rngs=rngs)
+
+    def __call__(self, x: jax.Array, train: bool = False):
+        h = nnx.relu(self.stem(x))                  # (B, d_model)
+        moe_out, balance_loss, util = self.moe(h, train=train)
+        h = self.norm(h + moe_out)                  # residual around the MoE block
+        logits = self.head(h)                       # (B, n_classes)
+        return logits, balance_loss, util
+
+
+def create_model(rngs: nnx.Rngs, *, in_features=32, n_classes=6, n_experts=4, k=2):
+    return MoEClassifier(
+        in_features=in_features,
+        d_model=64,
+        d_hidden=128,
+        n_experts=n_experts,
+        k=k,
+        n_classes=n_classes,
+        rngs=rngs,
+    )
+
+
+# ============================================================================
+# TRAIN STEP: total loss = task CE + AUX_COEF * balance_loss
+# ============================================================================
+
+@nnx.jit
+def train_step(model: MoEClassifier, optimizer: nnx.Optimizer, batch):
+    def loss_fn(model):
+        logits, balance_loss, util = model(batch["x"], train=True)
+        ce = optax.softmax_cross_entropy_with_integer_labels(logits, batch["y"]).mean()
+        total = ce + AUX_COEF * balance_loss
+        return total, (ce, balance_loss, util)
+
+    (total, (ce, balance_loss, util)), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return total, ce, balance_loss, util
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def _util_bar(util) -> str:
+    """One-line text histogram of expert utilization (fraction of routing slots)."""
+    return "  ".join(f"e{i}:{float(u):.2f}" for i, u in enumerate(util))
+
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 300))
+    batch_size = int(os.environ.get("BATCH", 512))
+    _ = os.environ.get("SYNTHETIC", "1")  # dataset is synthetic by construction
+
+    in_features, n_classes, n_experts, k = 32, 6, 4, 2
+    data = make_dataset(batch_size, in_features, n_classes, jax.random.key(0))
+
+    model = create_model(nnx.Rngs(0), in_features=in_features, n_classes=n_classes,
+                         n_experts=n_experts, k=k)
+    optimizer = nnx.Optimizer(model, optax.adam(3e-3), wrt=nnx.Param)
+
+    print(f"Training a top-{k}-of-{n_experts} MoE classifier for {epochs} steps "
+          f"({n_classes} classes, batch {batch_size})\n")
+    for step in range(epochs):
+        total, ce, bal, util = train_step(model, optimizer, data)
+        if step % 50 == 0 or step == epochs - 1:
+            acc = float(compute_accuracy(model(data["x"])[0], data["y"]))
+            print(f"step {step:4d} | total {float(total):.4f} | ce {float(ce):.4f} | "
+                  f"balance {float(bal):.3f} | acc {acc:.3f}")
+
+    _, _, util = model(data["x"])
+    print("\nFinal expert utilization (fraction of routing slots):")
+    print("  " + _util_bar(util))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scientific/neural_ode.py
+++ b/examples/scientific/neural_ode.py
@@ -1,0 +1,153 @@
+"""
+Neural ODE: Fitting a 2D Spiral with a Learned Vector Field
+===========================================================
+Learn continuous-depth dynamics dy/dt = f_theta(y) that reproduce a spiral
+trajectory. A fixed-step RK4 solver (hand-written with jax.lax.scan, no diffrax)
+integrates the network, and we backprop straight through the solver.
+
+Run: python scientific/neural_ode.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared.models import MLP
+from shared.training_utils import compute_mse_loss
+
+
+# ==== GROUND TRUTH: a known linear ODE that traces a decaying spiral ====
+# dy/dt = A y with eigenvalues -0.1 +/- i  =>  rotation (period ~2*pi) that
+# spirals inward. We integrate THIS with RK4 to manufacture the observations;
+# the network never sees A, only the trajectory it produces.
+A_TRUE = jnp.array([[-0.1, -1.0],
+                    [1.0, -0.1]])
+Y0 = jnp.array([2.0, 0.0])   # starting point of the spiral
+T = 8.0                       # integrate over t in [0, T] (~1.25 revolutions)
+
+
+def true_dynamics(t, y):
+    """Reference vector field dy/dt = A y (autonomous: t is ignored)."""
+    return y @ A_TRUE.T
+
+
+# ==== SOLVER: fixed-step classic RK4, built by hand with lax.scan ====
+def rk4_step(f, y, t, dt):
+    """One Runge-Kutta 4 step of dy/dt = f(t, y)."""
+    k1 = f(t, y)
+    k2 = f(t + dt / 2, y + dt / 2 * k1)
+    k3 = f(t + dt / 2, y + dt / 2 * k2)
+    k4 = f(t + dt, y + dt * k3)
+    return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+
+
+def odeint_rk4(f, y0, ts):
+    """Integrate dy/dt = f(t, y) over the grid `ts`, returning states (T, ...).
+
+    lax.scan turns the loop into a single differentiable op, so reverse-mode AD
+    can flow gradients through every step -- "discretize-then-optimize".
+    """
+    dt = ts[1] - ts[0]
+
+    def step(y, t):
+        y_next = rk4_step(f, y, t, dt)
+        return y_next, y_next
+
+    # Scan advances from t0..t_{T-2}; prepend y0 so we return all T states.
+    _, ys = jax.lax.scan(step, y0, ts[:-1])
+    return jnp.concatenate([y0[None], ys], axis=0)
+
+
+# ==== MODEL: an MLP vector field integrated by the solver ====
+class NeuralODE(nnx.Module):
+    """Continuous-depth model: an MLP dynamics f_theta(y) plugged into RK4."""
+
+    def __init__(self, hidden: int = 64, *, rngs: nnx.Rngs):
+        # f_theta: R^2 -> R^2. gelu is smooth, giving a well-behaved field.
+        self.func = MLP(
+            in_features=2,
+            hidden_features=hidden,
+            out_features=2,
+            n_layers=3,
+            rngs=rngs,
+            activation="gelu",
+        )
+        # Zero the final layer so the initial field is ~0: the untrained solver
+        # then stays near y0 instead of blowing up over many steps. This is the
+        # standard "start from the identity flow" trick for Neural ODEs.
+        self.func.output.kernel[...] = jnp.zeros_like(self.func.output.kernel[...])
+        self.func.output.bias[...] = jnp.zeros_like(self.func.output.bias[...])
+
+    def dynamics(self, t, y):
+        """Learned vector field; autonomous, so the time input is unused."""
+        return self.func(y)
+
+    def __call__(self, y0, ts):
+        """Integrate the learned field from y0 over ts -> trajectory (T, 2)."""
+        return odeint_rk4(self.dynamics, y0, ts)
+
+
+# ==== TRAIN STEP ====
+@nnx.jit
+def train_step(model: NeuralODE, optimizer: nnx.Optimizer, batch):
+    """One optimization step. `batch` = (y0, ts, target_trajectory)."""
+    y0, ts, target = batch
+
+    def loss_fn(model):
+        pred = model(y0, ts)                 # (T, 2)
+        loss = compute_mse_loss(pred, target)
+        return loss, pred
+
+    (loss, pred), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, pred
+
+
+# ==== DATA: synthetic spiral (no download, fully offline) ====
+def make_dataset(synthetic: bool = True, n_points: int = 80):
+    """Return (ts, true_trajectory) for the ground-truth spiral.
+
+    `synthetic` is accepted for parity with the other guides -- the spiral is
+    always generated locally by integrating the known linear ODE.
+    """
+    ts = jnp.linspace(0.0, T, n_points)
+    true_traj = odeint_rk4(true_dynamics, Y0, ts)   # (n_points, 2)
+    return ts, true_traj
+
+
+# ==== MAIN ====
+def main():
+    steps = int(os.environ.get("EPOCHS", "1000"))       # optimization steps
+    n_points = int(os.environ.get("BATCH", "80"))       # observations on curve
+    synthetic = os.environ.get("SYNTHETIC", "1") == "1"
+
+    rngs = nnx.Rngs(0)
+    model = NeuralODE(hidden=64, rngs=rngs)
+    optimizer = nnx.Optimizer(model, optax.adam(5e-3), wrt=nnx.Param)
+
+    ts, true_traj = make_dataset(synthetic=synthetic, n_points=n_points)
+    batch = (Y0, ts, true_traj)
+
+    print(f"Fitting dy/dt = f_theta(y) to a spiral on t in [0, {T}]")
+    print(f"steps={steps}  points={n_points}\n")
+
+    for step in range(steps):
+        loss, _ = train_step(model, optimizer, batch)
+        if step % 100 == 0 or step == steps - 1:
+            print(f"step {step:5d} | trajectory MSE {float(loss):.4e}")
+
+    pred = model(Y0, ts)
+    final_mse = float(compute_mse_loss(pred, true_traj))
+    endpoint_err = float(jnp.linalg.norm(pred[-1] - true_traj[-1]))
+    print(f"\nfinal trajectory MSE = {final_mse:.4e}")
+    print(f"endpoint error |y_pred(T) - y_true(T)| = {endpoint_err:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scientific/pinn_oscillator.py
+++ b/examples/scientific/pinn_oscillator.py
@@ -1,0 +1,139 @@
+"""
+Physics-Informed Neural Network: Damped Harmonic Oscillator
+===========================================================
+Solve the ODE  u'' + 2*zeta*omega*u' + omega^2*u = 0,  u(0)=1, u'(0)=0
+by *differentiating the network's output with respect to its input* with
+jax.grad and baking the residual straight into the loss. No dataset needed.
+
+Run: python scientific/pinn_oscillator.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+
+# ==== PHYSICS: the ODE and its analytic solution ====
+# u'' + 2*zeta*omega*u' + omega^2*u = 0 (underdamped, zeta < 1).
+OMEGA = 3.0    # natural angular frequency
+ZETA = 0.2     # damping ratio (0 < zeta < 1 => oscillatory decay)
+T = 4.0        # solve on t in [0, T]  (~2 damped periods)
+W_IC = 10.0    # weight on the initial-condition term (soft constraint)
+
+
+def analytic_solution(t, omega=OMEGA, zeta=ZETA):
+    """Closed-form underdamped response with u(0)=1, u'(0)=0 (for reference)."""
+    omega_d = omega * jnp.sqrt(1.0 - zeta ** 2)   # damped frequency
+    a = zeta * omega
+    return jnp.exp(-a * t) * (jnp.cos(omega_d * t) + (a / omega_d) * jnp.sin(omega_d * t))
+
+
+# ==== MODEL: a tiny t -> u(t) MLP with tanh activations ====
+# tanh is smooth, so its 1st and 2nd derivatives are well-behaved -- essential
+# because the physics loss differentiates the network twice.
+class PINN(nnx.Module):
+    """Scalar-in, scalar-out MLP approximating the solution u(t)."""
+
+    def __init__(self, hidden: int = 32, n_layers: int = 4, *, rngs: nnx.Rngs):
+        layers = [nnx.Linear(1, hidden, rngs=rngs)]
+        for _ in range(n_layers - 1):
+            layers.append(nnx.Linear(hidden, hidden, rngs=rngs))
+        # Plain python lists crash on Flax 0.12 -- wrap submodules in nnx.List.
+        self.layers = nnx.List(layers)
+        self.out = nnx.Linear(hidden, 1, rngs=rngs)
+
+    def __call__(self, t):
+        """t: (N, 1) collocation points -> (N, 1) predicted displacement."""
+        x = t
+        for layer in self.layers:
+            x = nnx.tanh(layer(x))
+        return self.out(x)
+
+
+# ==== LOSS: the ODE residual built from autodiff of the model ====
+def physics_loss(model: PINN, t_coll):
+    """Mean-squared ODE residual + initial-condition penalty.
+
+    The key move: define a scalar helper u(t), then take jax.grad twice to get
+    u'(t) and u''(t) *with respect to the input t*. vmap evaluates them at every
+    collocation point. This is differentiation of the MODEL, not a fit to data.
+    """
+    def u_fn(t):                       # t: scalar -> scalar u(t)
+        return model(t.reshape(1, 1))[0, 0]
+
+    u_t_fn = jax.grad(u_fn)            # du/dt   via autodiff
+    u_tt_fn = jax.grad(u_t_fn)        # d2u/dt2 via autodiff-of-autodiff
+
+    t_flat = t_coll[:, 0]
+    u = jax.vmap(u_fn)(t_flat)
+    u_t = jax.vmap(u_t_fn)(t_flat)
+    u_tt = jax.vmap(u_tt_fn)(t_flat)
+
+    residual = u_tt + 2.0 * ZETA * OMEGA * u_t + OMEGA ** 2 * u
+    loss_res = jnp.mean(residual ** 2)
+
+    # Initial conditions u(0)=1, u'(0)=0 as a soft penalty.
+    t0 = jnp.array(0.0)
+    loss_ic = (u_fn(t0) - 1.0) ** 2 + (u_t_fn(t0) - 0.0) ** 2
+
+    total = loss_res + W_IC * loss_ic
+    return total, {"residual": loss_res, "ic": loss_ic}
+
+
+# ==== TRAIN STEP ====
+@nnx.jit
+def train_step(model: PINN, optimizer: nnx.Optimizer, batch):
+    """One optimization step. `batch` is the (N, 1) array of collocation points."""
+    def loss_fn(model):
+        total, aux = physics_loss(model, batch)
+        return total, aux
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, aux
+
+
+# ==== DATA: collocation points (no dataset, PINNs are mesh-free) ====
+def make_dataset(synthetic: bool = True, n_collocation: int = 100):
+    """Return (N, 1) collocation points on [0, T].
+
+    PINNs need no training data -- the ODE *is* the supervision. `synthetic` is
+    accepted for API parity with the other guides; there is nothing to download.
+    """
+    return jnp.linspace(0.0, T, n_collocation).reshape(-1, 1)
+
+
+# ==== MAIN ====
+def main():
+    steps = int(os.environ.get("EPOCHS", "3000"))          # optimization steps
+    n_coll = int(os.environ.get("BATCH", "100"))           # collocation points
+    synthetic = os.environ.get("SYNTHETIC", "1") == "1"
+
+    rngs = nnx.Rngs(0)
+    model = PINN(hidden=32, n_layers=4, rngs=rngs)
+    optimizer = nnx.Optimizer(model, optax.adam(2e-3), wrt=nnx.Param)
+
+    t_coll = make_dataset(synthetic=synthetic, n_collocation=n_coll)
+
+    print(f"Solving u'' + 2*{ZETA}*{OMEGA}*u' + {OMEGA}^2*u = 0 on [0, {T}]")
+    print(f"steps={steps}  collocation={n_coll}\n")
+
+    for step in range(steps):
+        loss, aux = train_step(model, optimizer, t_coll)
+        if step % 500 == 0 or step == steps - 1:
+            print(f"step {step:5d} | loss {float(loss):.4e} | "
+                  f"residual {float(aux['residual']):.3e} | ic {float(aux['ic']):.3e}")
+
+    # Compare against the analytic solution on a fine grid.
+    t_eval = jnp.linspace(0.0, T, 200).reshape(-1, 1)
+    pred = model(t_eval)[:, 0]
+    ref = analytic_solution(t_eval[:, 0])
+    max_err = float(jnp.max(jnp.abs(pred - ref)))
+    print(f"\nmax |u_pred - u_analytic| over [0, {T}] = {max_err:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scientific/tabular_dnn.py
+++ b/examples/scientific/tabular_dnn.py
@@ -1,0 +1,236 @@
+"""
+Deep Learning for Tabular Data
+==============================
+A tabular DNN that learns a per-column embedding for every categorical feature,
+concatenates them with the numeric columns, and feeds an MLP -> classification
+head. All data is synthetic and generated offline with jax.random.
+
+Run: python scientific/tabular_dnn.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared.training_utils import (
+    compute_accuracy,
+    compute_cross_entropy_loss,
+    compute_mse_loss,
+)
+
+# ============================================================================
+# SCHEMA: a small mixed-type table
+# ============================================================================
+# Four numeric columns (already standardized) plus three categorical columns.
+# The cardinalities are the number of distinct categories each column can take,
+# e.g. a "city" column with 5 values, a "device" column with 8, a "plan" with 3.
+
+NUM_NUMERIC = 4
+CAT_CARDINALITIES = (5, 8, 3)   # one entry per categorical column
+NUM_CLASSES = 3
+
+
+def embedding_dims(cardinalities) -> tuple:
+    """Pick a small embedding width per categorical column.
+
+    A common rule of thumb is to grow the embedding sub-linearly with the
+    cardinality (fastai uses ~min(600, round(1.6 * card**0.56))). For these
+    tiny toy columns we use min(8, max(2, card // 2)).
+    """
+    return tuple(min(8, max(2, card // 2)) for card in cardinalities)
+
+
+# ============================================================================
+# SYNTHETIC DATA (offline): label is a nonlinear function of ALL features
+# ============================================================================
+
+def make_dataset(n_samples: int, *, seed: int = 0, task: str = "classification"):
+    """Generate a mixed numeric/categorical table with a nonlinear target.
+
+    A hidden generative process (never shown to the model) mixes nonlinear
+    numeric interactions with a random per-category effect table, so the model
+    genuinely has to (a) learn useful category embeddings and (b) model numeric
+    interactions. Returns a dict of jnp arrays; fully offline.
+    """
+    key = jax.random.key(seed)
+    k_num, k_wnum, k_cat_eff = jax.random.split(key, 3)
+
+    # --- numeric columns ~ N(0, 1) (pretend they are pre-standardized) --------
+    x_num = jax.random.normal(k_num, (n_samples, NUM_NUMERIC))
+
+    # --- integer-coded categorical columns ------------------------------------
+    cat_cols = []
+    for i, card in enumerate(CAT_CARDINALITIES):
+        k = jax.random.fold_in(key, 100 + i)
+        cat_cols.append(jax.random.randint(k, (n_samples,), 0, card))
+    x_cat = jnp.stack(cat_cols, axis=1).astype(jnp.int32)   # (N, n_cat)
+
+    # --- hidden ground truth: nonlinear numeric expansion + category effects --
+    feat = jnp.concatenate([
+        x_num,                                   # linear terms
+        jnp.sin(2.0 * x_num[:, :2]),             # nonlinearity
+        (x_num[:, 0] * x_num[:, 1])[:, None],    # interaction
+        (x_num[:, 2] ** 2)[:, None],             # curvature
+    ], axis=-1)
+    w = jax.random.normal(k_wnum, (feat.shape[1], NUM_CLASSES))
+    score = feat @ w                             # (N, NUM_CLASSES)
+
+    for i, card in enumerate(CAT_CARDINALITIES):
+        k = jax.random.fold_in(k_cat_eff, i)
+        table = jax.random.normal(k, (card, NUM_CLASSES)) * 1.5
+        score = score + table[x_cat[:, i]]       # add each column's effect
+
+    if task == "regression":
+        # A single continuous target: the same signal collapsed to a scalar.
+        y = score.sum(axis=-1)
+        return {"x_num": x_num, "x_cat": x_cat, "y": y}
+
+    y = jnp.argmax(score, axis=-1).astype(jnp.int32)
+    return {"x_num": x_num, "x_cat": x_cat, "y": y}
+
+
+# ============================================================================
+# MODEL: per-column embeddings -> concat with numeric -> MLP -> head
+# ============================================================================
+
+class TabularDNN(nnx.Module):
+    """Embed each categorical column, concat with numeric, then an MLP head.
+
+    Set out_features = NUM_CLASSES for classification, or out_features = 1 for
+    regression (the only thing that changes is the head width and the loss).
+    """
+
+    def __init__(
+        self,
+        num_numeric: int,
+        cat_cardinalities,
+        embed_dims,
+        hidden: int,
+        out_features: int,
+        *,
+        rngs: nnx.Rngs,
+    ):
+        # One embedding table per categorical column. A list of submodules MUST
+        # be wrapped in nnx.List so NNX registers them as state (Flax 0.12).
+        self.embeddings = nnx.List([
+            nnx.Embed(num_embeddings=card, features=dim, rngs=rngs)
+            for card, dim in zip(cat_cardinalities, embed_dims)
+        ])
+
+        concat_dim = num_numeric + sum(embed_dims)
+        self.fc1 = nnx.Linear(concat_dim, hidden, rngs=rngs)
+        self.fc2 = nnx.Linear(hidden, hidden, rngs=rngs)
+        self.dropout = nnx.Dropout(rate=0.1, rngs=rngs)
+        self.head = nnx.Linear(hidden, out_features, rngs=rngs)
+
+    def __call__(self, x_num: jax.Array, x_cat: jax.Array, train: bool = False):
+        """x_num: (B, num_numeric) float, x_cat: (B, n_cat) int."""
+        # Look up each column's embedding and concatenate everything.
+        embeds = [emb(x_cat[:, i]) for i, emb in enumerate(self.embeddings)]
+        h = jnp.concatenate([x_num, *embeds], axis=-1)
+
+        h = nnx.relu(self.fc1(h))
+        h = self.dropout(h, deterministic=not train)
+        h = nnx.relu(self.fc2(h))
+        return self.head(h)          # (B, out_features) logits or regression value
+
+
+def create_model(rngs: nnx.Rngs, *, hidden: int = 64, task: str = "classification"):
+    """Build a TabularDNN for the fixed toy schema."""
+    out_features = 1 if task == "regression" else NUM_CLASSES
+    return TabularDNN(
+        num_numeric=NUM_NUMERIC,
+        cat_cardinalities=CAT_CARDINALITIES,
+        embed_dims=embedding_dims(CAT_CARDINALITIES),
+        hidden=hidden,
+        out_features=out_features,
+        rngs=rngs,
+    )
+
+
+# ============================================================================
+# TRAIN STEPS (classification + regression variants)
+# ============================================================================
+
+@nnx.jit
+def train_step(model: TabularDNN, optimizer: nnx.Optimizer, batch):
+    """Classification step: cross-entropy loss, reports accuracy."""
+    def loss_fn(model):
+        logits = model(batch["x_num"], batch["x_cat"], train=True)
+        loss = compute_cross_entropy_loss(logits, batch["y"])
+        acc = compute_accuracy(logits, batch["y"])
+        return loss, acc
+
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+
+@nnx.jit
+def train_step_regression(model: TabularDNN, optimizer: nnx.Optimizer, batch):
+    """Regression step: mean-squared-error on the single scalar head."""
+    def loss_fn(model):
+        preds = model(batch["x_num"], batch["x_cat"], train=True)[:, 0]
+        loss = compute_mse_loss(preds, batch["y"])
+        return loss, loss
+
+    (loss, _), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, loss
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 15))          # passes over the table
+    batch_size = int(os.environ.get("BATCH", 256))
+    n_samples = int(os.environ.get("N_SAMPLES", 2000))
+    task = os.environ.get("TASK", "classification")     # or "regression"
+    _ = os.environ.get("SYNTHETIC", "1")                # always synthetic/offline
+
+    data = make_dataset(n_samples, task=task)
+    step_fn = train_step_regression if task == "regression" else train_step
+
+    model = create_model(nnx.Rngs(0), task=task)
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    print(f"Tabular DNN ({task}) | {n_samples} rows | "
+          f"{NUM_NUMERIC} numeric + {len(CAT_CARDINALITIES)} categorical columns "
+          f"(cardinalities {CAT_CARDINALITIES}, embeds {embedding_dims(CAT_CARDINALITIES)})\n")
+
+    n_batches = max(1, n_samples // batch_size)
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.key(epoch), n_samples)
+        last_loss, last_acc = 0.0, 0.0
+        for b in range(n_batches):
+            idx = perm[b * batch_size:(b + 1) * batch_size]
+            batch = {
+                "x_num": data["x_num"][idx],
+                "x_cat": data["x_cat"][idx],
+                "y": data["y"][idx],
+            }
+            last_loss, last_acc = step_fn(model, optimizer, batch)
+
+        if task == "regression":
+            print(f"epoch {epoch:2d} | mse {float(last_loss):.4f}")
+        else:
+            print(f"epoch {epoch:2d} | loss {float(last_loss):.4f} | "
+                  f"batch acc {float(last_acc):.3f}")
+
+    if task != "regression":
+        logits = model(data["x_num"], data["x_cat"], train=False)
+        final_acc = float(compute_accuracy(logits, data["y"]))
+        print(f"\nFinal full-dataset accuracy: {final_acc:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sequence/__init__.py
+++ b/examples/sequence/__init__.py
@@ -1,0 +1,1 @@
+"""sequence examples."""

--- a/examples/sequence/rnn_cells.py
+++ b/examples/sequence/rnn_cells.py
@@ -1,0 +1,226 @@
+"""
+Recurrent Networks: RNN / LSTM / GRU / Bidirectional
+====================================================
+Recurrent classifiers on a synthetic parity task, built with the Flax NNX
+`nnx.RNN` / `nnx.LSTMCell` / `nnx.GRUCell` / `nnx.SimpleCell` / `nnx.Bidirectional`
+API, plus a hand-written `nnx.scan` loop that shows how carry threading works.
+
+Run: python sequence/rnn_cells.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import compute_accuracy, compute_cross_entropy_loss
+
+
+# ============================================================================
+# MODELS
+# ============================================================================
+
+class LSTMClassifier(nnx.Module):
+    """Embed tokens -> LSTM over time -> classify from the last hidden state.
+
+    ``nnx.RNN`` wraps a recurrent cell and scans it across the time axis of a
+    ``(B, T, features)`` input, returning the per-step outputs ``(B, T, hidden)``.
+    """
+
+    def __init__(self, vocab: int, embed: int, hidden: int, n_classes: int,
+                 *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.LSTMCell(embed, hidden, rngs=rngs))
+        self.head = nnx.Linear(hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)      # (B, T)      -> (B, T, embed)
+        h = self.rnn(h)             # (B, T, embed) -> (B, T, hidden)
+        return self.head(h[:, -1])  # last step   -> (B, n_classes)
+
+
+class GRUClassifier(nnx.Module):
+    """Same as LSTMClassifier but with a GRU cell (single gated carry ``h``)."""
+
+    def __init__(self, vocab: int, embed: int, hidden: int, n_classes: int,
+                 *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.GRUCell(embed, hidden, rngs=rngs))
+        self.head = nnx.Linear(hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)
+        h = self.rnn(h)
+        return self.head(h[:, -1])
+
+
+class VanillaRNNClassifier(nnx.Module):
+    """Elman/vanilla RNN via ``nnx.SimpleCell`` — no gates, prone to vanishing
+    gradients on long sequences. Kept here to contrast against LSTM/GRU."""
+
+    def __init__(self, vocab: int, embed: int, hidden: int, n_classes: int,
+                 *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.SimpleCell(embed, hidden, rngs=rngs))
+        self.head = nnx.Linear(hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)
+        h = self.rnn(h)
+        return self.head(h[:, -1])
+
+
+class BiLSTMClassifier(nnx.Module):
+    """Bidirectional LSTM. ``nnx.Bidirectional`` runs a forward and a backward
+    RNN and concatenates their outputs, so the head sees ``2 * hidden`` features
+    that summarise context from both directions."""
+
+    def __init__(self, vocab: int, embed: int, hidden: int, n_classes: int,
+                 *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        forward = nnx.RNN(nnx.LSTMCell(embed, hidden, rngs=rngs))
+        backward = nnx.RNN(nnx.LSTMCell(embed, hidden, rngs=rngs))
+        self.birnn = nnx.Bidirectional(forward, backward)
+        self.head = nnx.Linear(2 * hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)      # (B, T, embed)
+        h = self.birnn(h)           # (B, T, 2*hidden)  (fwd ++ bwd)
+        return self.head(h[:, -1])
+
+
+MODELS = {
+    "lstm": LSTMClassifier,
+    "gru": GRUClassifier,
+    "rnn": VanillaRNNClassifier,
+    "bilstm": BiLSTMClassifier,
+}
+
+
+# ============================================================================
+# MANUAL SCAN — carry threading under the hood
+# ============================================================================
+
+def manual_lstm_scan(cell: nnx.LSTMCell, sequence: jax.Array):
+    """Reproduce what ``nnx.RNN`` does internally.
+
+    A recurrent layer is a ``scan``: at each step ``t`` the cell maps
+    ``(carry, x_t) -> (carry, y_t)``, threading the ``carry`` (for an LSTM the
+    pair ``(h, c)``) from one step to the next. ``nnx.scan`` with
+    ``in_axes=(nnx.Carry, 1)`` marks the first argument as the threaded carry
+    and slices the *other* argument along the time axis (axis 1). ``out_axes``
+    likewise stacks the per-step outputs back along axis 1.
+
+    Args:
+        cell: an ``nnx.LSTMCell`` with matching ``in_features``.
+        sequence: ``(B, T, in_features)`` input.
+
+    Returns:
+        ``(carry, outputs)`` where ``carry`` is the final ``(h, c)`` and
+        ``outputs`` is ``(B, T, hidden)``.
+    """
+    batch = sequence.shape[0]
+    in_features = sequence.shape[-1]
+    carry = cell.initialize_carry((batch, in_features), nnx.Rngs(0))
+
+    @nnx.scan(in_axes=(nnx.Carry, 1), out_axes=(nnx.Carry, 1))
+    def step(carry, x_t):
+        carry, y_t = cell(carry, x_t)   # (h, c), x_t -> (h, c), y_t
+        return carry, y_t
+
+    carry, outputs = step(carry, sequence)
+    return carry, outputs
+
+
+# ============================================================================
+# DATA — synthetic parity task
+# ============================================================================
+
+def make_dataset(synthetic: bool = True, *, n: int = 512, seq_len: int = 12,
+                 vocab: int = 10, seed: int = 0):
+    """Parity task: label = (sum of tokens) mod 2.
+
+    Solving it forces the network to *integrate information across every time
+    step* — a single missed token flips the label — so it is a clean stress
+    test of recurrent memory. There is no external dataset to download here;
+    ``synthetic=False`` just generates a larger, longer (harder) version.
+
+    Returns:
+        ``(x, y)`` with ``x: (n, seq_len) int32`` tokens and ``y: (n,) int32``
+        parity labels in ``{0, 1}``.
+    """
+    if not synthetic:
+        n, seq_len = max(n, 4096), max(seq_len, 20)
+    key = jax.random.key(seed)
+    x = jax.random.randint(key, (n, seq_len), 0, vocab)
+    y = (x.sum(axis=1) % 2).astype(jnp.int32)
+    return x, y
+
+
+# ============================================================================
+# TRAIN STEP
+# ============================================================================
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["x"])
+        loss = compute_cross_entropy_loss(logits, batch["y"])
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    acc = compute_accuracy(logits, batch["y"])
+    return loss, acc
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 40))
+    batch_size = int(os.environ.get("BATCH", 128))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+    which = os.environ.get("MODEL", "lstm")
+
+    vocab, embed, hidden, n_classes = 10, 32, 64, 2
+
+    x, y = make_dataset(synthetic=synthetic, vocab=vocab)
+    n = x.shape[0]
+
+    rngs = nnx.Rngs(0)
+    model = MODELS[which](vocab, embed, hidden, n_classes, rngs=rngs)
+    tx = optax.adam(1e-2)
+    optimizer = nnx.Optimizer(model, tx, wrt=nnx.Param)
+
+    print(f"model={which} samples={n} seq_len={x.shape[1]} "
+          f"epochs={epochs} batch={batch_size}")
+
+    step = 0
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.key(epoch), n)
+        for i in range(0, n - batch_size + 1, batch_size):
+            idx = perm[i:i + batch_size]
+            batch = {"x": x[idx], "y": y[idx]}
+            loss, acc = train_step(model, optimizer, batch)
+            step += 1
+        print(f"epoch {epoch:2d}  loss {float(loss):.4f}  acc {float(acc):.4f}")
+
+    # Demonstrate the manual scan matches the high-level nnx.RNN wrapper.
+    demo_cell = nnx.LSTMCell(embed, hidden, rngs=nnx.Rngs(0))
+    seq = jnp.ones((4, x.shape[1], embed))
+    (h, c), outputs = manual_lstm_scan(demo_cell, seq)
+    print(f"manual scan outputs {outputs.shape}  carry h {h.shape}  c {c.shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sequence/seq2seq_attention.py
+++ b/examples/sequence/seq2seq_attention.py
@@ -1,0 +1,180 @@
+"""
+Sequence-to-Sequence with Attention
+====================================
+An encoder-decoder that maps a source token sequence to a target sequence,
+here the synthetic copy-and-reverse task (target = reversed input). The decoder
+uses cross-attention (nnx.MultiHeadAttention) over the encoder states, with
+teacher forcing. This is the conditional source->target counterpart to a
+decoder-only GPT.
+
+Run: python sequence/seq2seq_attention.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import compute_accuracy, compute_cross_entropy_loss
+
+
+# ============================================================================
+# MODEL
+# ============================================================================
+
+class Encoder(nnx.Module):
+    """Embed source tokens -> GRU over time -> per-step encoder states.
+
+    ``nnx.RNN`` scans the GRU cell across the time axis of a ``(B, T)`` token
+    sequence and returns the full stack of hidden states ``(B, T, hidden)``.
+    The decoder attends over *all* of these, not just the last one.
+    """
+
+    def __init__(self, vocab: int, embed: int, hidden: int, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.GRUCell(embed, hidden, rngs=rngs))
+
+    def __call__(self, src):
+        h = self.embed(src)   # (B, T)      -> (B, T, embed)
+        return self.rnn(h)    # (B, T, embed) -> (B, T, hidden)   encoder states
+
+
+class Decoder(nnx.Module):
+    """Teacher-forced GRU decoder with cross-attention over encoder states.
+
+    At every output step the decoder forms a query from its own recurrent
+    state and attends over the encoder states (keys/values). The resulting
+    context vector is concatenated with the decoder state and projected to the
+    vocabulary. This is the encoder-decoder attention of Bahdanau et al.,
+    expressed with the built-in ``nnx.MultiHeadAttention``.
+    """
+
+    def __init__(self, vocab: int, embed: int, hidden: int, num_heads: int,
+                 *, rngs: nnx.Rngs):
+        # vocab + 1: the extra id is the <bos> start token fed at step 0.
+        self.embed = nnx.Embed(vocab + 1, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.GRUCell(embed, hidden, rngs=rngs))
+        self.cross_attn = nnx.MultiHeadAttention(
+            num_heads=num_heads,
+            in_features=hidden,      # query dim (decoder state)
+            in_kv_features=hidden,   # key/value dim (encoder states)
+            qkv_features=hidden,
+            decode=False,
+            rngs=rngs,
+        )
+        self.out = nnx.Linear(2 * hidden, vocab, rngs=rngs)
+
+    def __call__(self, dec_in, enc_states):
+        d = self.embed(dec_in)          # (B, T)      -> (B, T, embed)
+        d = self.rnn(d)                 # (B, T, embed) -> (B, T, hidden)  decoder states
+        # Cross-attention: query = decoder states, key/value = encoder states.
+        ctx = self.cross_attn(d, enc_states, enc_states)   # (B, T, hidden)  context
+        combined = jnp.concatenate([d, ctx], axis=-1)      # (B, T, 2*hidden)
+        return self.out(combined)                          # (B, T, vocab)   logits
+
+
+class Seq2SeqAttention(nnx.Module):
+    """Encoder + attention decoder wired together."""
+
+    def __init__(self, vocab: int, embed: int, hidden: int, num_heads: int,
+                 *, rngs: nnx.Rngs):
+        self.encoder = Encoder(vocab, embed, hidden, rngs=rngs)
+        self.decoder = Decoder(vocab, embed, hidden, num_heads, rngs=rngs)
+
+    def __call__(self, src, dec_in):
+        enc_states = self.encoder(src)              # (B, T, hidden)
+        return self.decoder(dec_in, enc_states)     # (B, T_out, vocab)
+
+
+# ============================================================================
+# DATA — synthetic copy-and-reverse task
+# ============================================================================
+
+def make_dataset(synthetic: bool = True, *, n: int = 1024, seq_len: int = 8,
+                 vocab: int = 12, seed: int = 0):
+    """Copy-and-reverse: the target is the source sequence read backwards.
+
+    ``src = [a, b, c, d]``  ->  ``tgt = [d, c, b, a]``. Solving it forces the
+    decoder to align output step ``t`` with source position ``T-1-t`` — an
+    alignment that cross-attention learns to express. Everything is generated
+    in-memory; ``synthetic=False`` just makes a larger, longer (harder) version.
+
+    Returns a dict with:
+        ``src``     (n, T)   int32 source tokens in ``[0, vocab)``
+        ``dec_in``  (n, T)   int32 teacher-forcing input: ``<bos>`` + tgt[:-1]
+        ``tgt``     (n, T)   int32 target tokens (reversed source)
+    where the ``<bos>`` id is ``vocab``.
+    """
+    if not synthetic:
+        n, seq_len = max(n, 8192), max(seq_len, 12)
+    key = jax.random.key(seed)
+    src = jax.random.randint(key, (n, seq_len), 0, vocab).astype(jnp.int32)
+    tgt = src[:, ::-1]                                   # reversed sequence
+    bos = jnp.full((n, 1), vocab, dtype=jnp.int32)       # start-of-sequence id
+    dec_in = jnp.concatenate([bos, tgt[:, :-1]], axis=1)  # shift-right teacher forcing
+    return {"src": src, "dec_in": dec_in, "tgt": tgt}
+
+
+# ============================================================================
+# TRAIN STEP
+# ============================================================================
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["src"], batch["dec_in"])   # (B, T, vocab)
+        B, T, V = logits.shape
+        flat_logits = logits.reshape(B * T, V)
+        flat_tgt = batch["tgt"].reshape(B * T)
+        loss = compute_cross_entropy_loss(flat_logits, flat_tgt)
+        acc = compute_accuracy(flat_logits, flat_tgt)    # per-token accuracy
+        return loss, acc
+
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 30))
+    batch_size = int(os.environ.get("BATCH", 128))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+
+    vocab, embed, hidden, num_heads = 12, 32, 64, 4
+
+    data = make_dataset(synthetic=synthetic, vocab=vocab)
+    n = data["src"].shape[0]
+    seq_len = data["src"].shape[1]
+
+    rngs = nnx.Rngs(0)
+    model = Seq2SeqAttention(vocab, embed, hidden, num_heads, rngs=rngs)
+    tx = optax.adam(3e-3)
+    optimizer = nnx.Optimizer(model, tx, wrt=nnx.Param)
+
+    print(f"seq2seq+attention  samples={n} seq_len={seq_len} vocab={vocab} "
+          f"epochs={epochs} batch={batch_size}")
+
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.key(epoch), n)
+        loss = acc = 0.0
+        for i in range(0, n - batch_size + 1, batch_size):
+            idx = perm[i:i + batch_size]
+            batch = {k: v[idx] for k, v in data.items()}
+            loss, acc = train_step(model, optimizer, batch)
+        print(f"epoch {epoch:2d}  loss {float(loss):.4f}  token_acc {float(acc):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sequence/time_series.py
+++ b/examples/sequence/time_series.py
@@ -1,0 +1,184 @@
+"""
+LSTM Time-Series Forecasting
+============================
+Windowed multi-step forecasting with an ``nnx.RNN(nnx.LSTMCell)`` encoder and a
+linear head. The signal is a synthetic sum of sinusoids plus noise, sliced into
+sliding windows: read ``L`` past steps, predict the next ``H`` steps (MSE).
+
+Run: python sequence/time_series.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import compute_mse_loss
+
+
+# ============================================================================
+# MODEL
+# ============================================================================
+
+class LSTMForecaster(nnx.Module):
+    """Encode a window of ``L`` past values, forecast the next ``H`` values.
+
+    ``nnx.RNN`` scans ``nnx.LSTMCell`` across the time axis of a
+    ``(B, L, in_features)`` window and returns per-step hidden states
+    ``(B, L, hidden)``. The last state summarizes the whole window; a
+    ``nnx.Linear`` head maps it to the ``H``-step forecast (regression).
+    """
+
+    def __init__(self, in_features: int, hidden: int, horizon: int,
+                 *, rngs: nnx.Rngs):
+        self.rnn = nnx.RNN(nnx.LSTMCell(in_features, hidden, rngs=rngs))
+        self.head = nnx.Linear(hidden, horizon, rngs=rngs)
+
+    def __call__(self, x):
+        h = self.rnn(x)             # (B, L, in_features) -> (B, L, hidden)
+        return self.head(h[:, -1])  # last step           -> (B, horizon)
+
+
+# ============================================================================
+# DATA — synthetic sum-of-sinusoids series + sliding windows
+# ============================================================================
+
+def make_series(length: int, *, seed: int = 0) -> jax.Array:
+    """Generate a 1-D signal: sum of sinusoids of different periods + noise.
+
+    This is a self-contained stand-in for a real univariate series (energy
+    load, temperature, sensor reading): several periodic components make it
+    predictable, while the additive noise stops the model from memorizing.
+
+    Returns:
+        ``(length,)`` float32 series.
+    """
+    t = jnp.arange(length, dtype=jnp.float32)
+    series = (
+        1.0 * jnp.sin(2 * jnp.pi * t / 24.0)     # daily-like cycle
+        + 0.5 * jnp.sin(2 * jnp.pi * t / 168.0)  # weekly-like cycle
+        + 0.3 * jnp.sin(2 * jnp.pi * t / 7.0)    # short ripple
+    )
+    noise = 0.1 * jax.random.normal(jax.random.key(seed), (length,))
+    return series + noise
+
+
+def make_windows(series: jax.Array, window: int, horizon: int):
+    """Slice a series into ``(input window -> next horizon steps)`` pairs.
+
+    Returns:
+        ``x: (N, window, 1)`` input windows and ``y: (N, horizon)`` targets,
+        where ``N = len(series) - window - horizon + 1``.
+    """
+    n = series.shape[0] - window - horizon + 1
+    starts = jnp.arange(n)
+    x = jax.vmap(lambda s: jax.lax.dynamic_slice(series, (s,), (window,)))(starts)
+    y = jax.vmap(
+        lambda s: jax.lax.dynamic_slice(series, (s + window,), (horizon,))
+    )(starts)
+    return x[..., None], y  # (N, window, 1), (N, horizon)
+
+
+def make_dataset(synthetic: bool = True, *, window: int = 48, horizon: int = 12,
+                 seed: int = 0):
+    """Build a normalized train/test split from one synthetic series.
+
+    The series is split in time (past = train, future = test) *before*
+    windowing, so the test windows are a genuine held-out continuation. We
+    standardize using train statistics only, to avoid leaking the future.
+
+    Returns:
+        ``(x_tr, y_tr, x_te, y_te, stats)`` with ``stats = (mean, std)``.
+    """
+    length = 512 if synthetic else 2048
+    series = make_series(length, seed=seed)
+
+    split = int(0.8 * length)
+    mean = series[:split].mean()
+    std = series[:split].std() + 1e-6
+    series = (series - mean) / std
+
+    # Overlap the two halves by `window` so the first test target immediately
+    # follows the training region without dropping any continuation steps.
+    train_series = series[:split]
+    test_series = series[split - window:]
+
+    x_tr, y_tr = make_windows(train_series, window, horizon)
+    x_te, y_te = make_windows(test_series, window, horizon)
+    return x_tr, y_tr, x_te, y_te, (mean, std)
+
+
+# ============================================================================
+# TRAIN / EVAL STEPS
+# ============================================================================
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        preds = model(batch["x"])            # (B, horizon)
+        loss = compute_mse_loss(preds, batch["y"])
+        return loss, preds
+
+    (loss, preds), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, preds
+
+
+@nnx.jit
+def eval_mse(model, x, y):
+    return compute_mse_loss(model(x), y)
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 40))
+    batch_size = int(os.environ.get("BATCH", 64))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+
+    window, horizon, hidden = 48, 12, 64
+
+    x_tr, y_tr, x_te, y_te, _ = make_dataset(
+        synthetic=synthetic, window=window, horizon=horizon)
+    n = x_tr.shape[0]
+
+    rngs = nnx.Rngs(0)
+    model = LSTMForecaster(in_features=1, hidden=hidden, horizon=horizon, rngs=rngs)
+    tx = optax.adam(5e-3)
+    optimizer = nnx.Optimizer(model, tx, wrt=nnx.Param)
+
+    print(f"train_windows={n} test_windows={x_te.shape[0]} "
+          f"window={window} horizon={horizon} epochs={epochs} batch={batch_size}")
+
+    for epoch in range(epochs):
+        perm = jax.random.permutation(jax.random.key(epoch), n)
+        for i in range(0, n - batch_size + 1, batch_size):
+            idx = perm[i:i + batch_size]
+            batch = {"x": x_tr[idx], "y": y_tr[idx]}
+            loss, _ = train_step(model, optimizer, batch)
+        test_mse = eval_mse(model, x_te, y_te)
+        if epoch % 5 == 0 or epoch == epochs - 1:
+            print(f"epoch {epoch:2d}  train_mse {float(loss):.4f}  "
+                  f"test_mse {float(test_mse):.4f}")
+
+    # Forecast the first held-out window and compare to the true continuation.
+    forecast = model(x_te[:1])[0]        # (horizon,)
+    truth = y_te[0]                      # (horizon,)
+    final_mse = float(jnp.mean((forecast - truth) ** 2))
+    print(f"held-out forecast MSE (first window): {final_mse:.4f}")
+    print(f"forecast[:4] {jnp.round(forecast[:4], 3)}  "
+          f"truth[:4] {jnp.round(truth[:4], 3)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sequence/word2vec.py
+++ b/examples/sequence/word2vec.py
@@ -1,0 +1,258 @@
+"""
+Word2Vec: Skip-Gram with Negative Sampling
+===========================================
+Learn dense word embeddings from a tiny hardcoded corpus using the skip-gram
+with negative sampling (SGNS) objective, built from two ``nnx.Embed`` tables.
+After training, cosine-nearest neighbours recover the corpus's semantic themes.
+
+Run: python sequence/word2vec.py
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path for shared imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ============================================================================
+# DATA — a tiny themed corpus (fully self-contained, no downloads)
+# ============================================================================
+
+# Very frequent "glue" words carry little meaning and co-occur with everything,
+# so we drop them before building pairs. This is the tutorial-sized version of
+# Word2Vec's frequent-word subsampling and keeps the learned clusters crisp.
+STOPWORDS = {"the", "a", "and", "on", "in", "of", "with", "over", "under",
+             "across", "toward", "above", "past"}
+
+# Four semantic themes. Words inside a theme co-occur with each other and never
+# with words from another theme, so skip-gram should pull each theme together.
+CORPUS = [
+    # royalty
+    "king and queen rule the royal palace",
+    "prince and princess wear the golden crown",
+    "royal king and queen sit on the throne",
+    "crown throne palace king queen prince princess royal",
+    "golden crown royal throne palace",
+    # ocean
+    "boat sail across the deep blue ocean",
+    "fish swim under the ocean wave",
+    "sailor steer the boat over the ocean water",
+    "blue ocean wave boat fish sail water deep",
+    "deep ocean water hold the fish and boat",
+    # space
+    "rocket fly toward a distant star",
+    "planet orbit the star and moon glow",
+    "rocket reach orbit above the distant planet",
+    "star planet moon rocket orbit galaxy comet sky",
+    "comet streak past the moon and distant star",
+    # music
+    "band play a song with guitar and drum",
+    "singer sing the melody and guitar play",
+    "drum guitar blend the melody of the song",
+    "song melody guitar drum band singer tune rhythm",
+    "band play a joyful tune and melody",
+]
+
+# Ground-truth themes, used only to sanity-check the learned neighbours.
+THEMES = {
+    "royalty": ["king", "queen", "prince", "princess", "royal", "throne",
+                "crown", "palace", "golden", "rule", "wear", "sit"],
+    "ocean": ["boat", "ocean", "wave", "fish", "sail", "sailor", "blue",
+              "water", "deep", "swim", "steer", "hold"],
+    "space": ["rocket", "moon", "star", "planet", "orbit", "galaxy", "comet",
+              "sky", "distant", "fly", "reach", "glow", "streak"],
+    "music": ["band", "song", "guitar", "drum", "melody", "singer", "tune",
+              "rhythm", "play", "sing", "blend", "joyful"],
+}
+
+
+def tokenize(line):
+    """Lowercase, split, and drop stopwords."""
+    return [w for w in line.lower().split() if w not in STOPWORDS]
+
+
+def build_vocab(corpus):
+    """Map every (non-stopword) token to an integer id (sorted for determinism)."""
+    tokens = sorted({w for line in corpus for w in tokenize(line)})
+    stoi = {w: i for i, w in enumerate(tokens)}
+    itos = tokens
+    return stoi, itos
+
+
+def build_skipgram_pairs(corpus, stoi, window: int = 2):
+    """Turn the corpus into (center, context) id pairs.
+
+    For each token we emit one pair per neighbour inside ``[-window, +window]``,
+    which is exactly the set of positive examples the skip-gram model must score
+    highly. Returns two ``(N,) int32`` arrays.
+    """
+    centers, contexts = [], []
+    for line in corpus:
+        ids = [stoi[w] for w in tokenize(line)]
+        for i, center in enumerate(ids):
+            lo, hi = max(0, i - window), min(len(ids), i + window + 1)
+            for j in range(lo, hi):
+                if j == i:
+                    continue
+                centers.append(center)
+                contexts.append(ids[j])
+    return np.asarray(centers, np.int32), np.asarray(contexts, np.int32)
+
+
+def sample_negatives(key, n: int, vocab_size: int, k: int):
+    """Draw ``k`` uniform-random negative context ids per positive pair.
+
+    Word2Vec's original paper uses a unigram^0.75 distribution; uniform is a fine
+    approximation on a small balanced vocabulary and keeps the demo transparent.
+    Returns an ``(n, k) int32`` array.
+    """
+    return jax.random.randint(key, (n, k), 0, vocab_size).astype(jnp.int32)
+
+
+# ============================================================================
+# MODEL — two embedding tables (center "input" + context "output")
+# ============================================================================
+
+class SkipGramNS(nnx.Module):
+    """Skip-gram with negative sampling.
+
+    Two ``nnx.Embed`` tables of shape ``(vocab, dim)``: ``center`` holds the
+    "input" word vectors we ultimately keep, ``context`` holds the "output"
+    vectors used to score neighbours. The score of a (center, context) pair is
+    their dot product; training pushes true pairs up and sampled negatives down.
+    """
+
+    def __init__(self, vocab_size: int, dim: int, *, rngs: nnx.Rngs):
+        self.center = nnx.Embed(vocab_size, dim, rngs=rngs)
+        self.context = nnx.Embed(vocab_size, dim, rngs=rngs)
+
+    def __call__(self, center_ids, context_ids, negative_ids):
+        v_c = self.center(center_ids)              # (B, D)  center vectors
+        u_o = self.context(context_ids)            # (B, D)  positive contexts
+        u_n = self.context(negative_ids)           # (B, K, D) negatives
+        pos_score = jnp.sum(v_c * u_o, axis=-1)                 # (B,)
+        neg_score = jnp.einsum("bd,bkd->bk", v_c, u_n)          # (B, K)
+        return pos_score, neg_score
+
+    def word_vectors(self):
+        """The learned input embeddings — the vectors you export and reuse."""
+        return self.center.embedding[...]          # (vocab, D)
+
+
+def sgns_loss(pos_score, neg_score):
+    """Negative-sampling loss (a sigmoid BCE, summed over K negatives).
+
+    $-\\log \\sigma(v_c \\cdot u_o) - \\sum_k \\log \\sigma(-v_c \\cdot u_{n_k})$,
+    averaged over the batch. ``jax.nn.log_sigmoid`` is the numerically stable
+    ``log(sigmoid(x))``.
+    """
+    pos = -jax.nn.log_sigmoid(pos_score)                       # want score high
+    neg = -jax.nn.log_sigmoid(-neg_score).sum(axis=-1)        # want scores low
+    return jnp.mean(pos + neg)
+
+
+# ============================================================================
+# TRAIN STEP
+# ============================================================================
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        pos_score, neg_score = model(
+            batch["center"], batch["context"], batch["negatives"]
+        )
+        loss = sgns_loss(pos_score, neg_score)
+        return loss, (pos_score, neg_score)
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, aux
+
+
+# ============================================================================
+# NEAREST NEIGHBOURS (cosine)
+# ============================================================================
+
+def nearest_neighbors(vectors, itos, word: str, stoi, k: int = 5):
+    """Return the ``k`` most cosine-similar words to ``word`` (excluding itself)."""
+    normed = vectors / (jnp.linalg.norm(vectors, axis=1, keepdims=True) + 1e-8)
+    sims = normed @ normed[stoi[word]]
+    order = jnp.argsort(sims)[::-1]
+    out = []
+    for i in order.tolist():
+        if itos[i] == word:
+            continue
+        out.append((itos[i], float(sims[i])))
+        if len(out) == k:
+            break
+    return out
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def main():
+    epochs = int(os.environ.get("EPOCHS", 200))
+    batch_size = int(os.environ.get("BATCH", 128))
+    # SYNTHETIC is honoured for interface consistency; this corpus is always
+    # self-contained, so there is nothing to download either way.
+    _ = os.environ.get("SYNTHETIC", "1")
+
+    dim = int(os.environ.get("DIM", 32))
+    window = int(os.environ.get("WINDOW", 2))
+    n_negatives = int(os.environ.get("NEG", 6))
+
+    stoi, itos = build_vocab(CORPUS)
+    vocab_size = len(itos)
+    centers, contexts = build_skipgram_pairs(CORPUS, stoi, window=window)
+    n_pairs = centers.shape[0]
+
+    rngs = nnx.Rngs(0)
+    model = SkipGramNS(vocab_size, dim, rngs=rngs)
+    optimizer = nnx.Optimizer(model, optax.adam(5e-2), wrt=nnx.Param)
+
+    print(f"vocab={vocab_size} pairs={n_pairs} dim={dim} "
+          f"neg={n_negatives} epochs={epochs} batch={batch_size}")
+
+    key = jax.random.key(0)
+    centers_j = jnp.asarray(centers)
+    contexts_j = jnp.asarray(contexts)
+    step = 0
+    for epoch in range(epochs):
+        key, pkey = jax.random.split(key)
+        perm = jax.random.permutation(pkey, n_pairs)
+        for i in range(0, n_pairs - batch_size + 1, batch_size) or [0]:
+            idx = perm[i:i + batch_size]
+            key, nkey = jax.random.split(key)
+            batch = {
+                "center": centers_j[idx],
+                "context": contexts_j[idx],
+                "negatives": sample_negatives(
+                    nkey, idx.shape[0], vocab_size, n_negatives
+                ),
+            }
+            loss, _ = train_step(model, optimizer, batch)
+            step += 1
+        if epoch % 20 == 0 or epoch == epochs - 1:
+            print(f"epoch {epoch:3d}  loss {float(loss):.4f}")
+
+    vectors = model.word_vectors()
+    print("\nNearest neighbours (cosine):")
+    for probe in ["king", "ocean", "rocket", "guitar"]:
+        nbrs = nearest_neighbors(vectors, itos, probe, stoi, k=4)
+        pretty = ", ".join(f"{w}:{s:.2f}" for w, s in nbrs)
+        print(f"  {probe:8s} -> {pretty}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/shared/models.py
+++ b/examples/shared/models.py
@@ -374,3 +374,50 @@ class ResNetBlock(nnx.Module):
         x = nnx.relu(x)
         
         return x
+
+
+# ============================================================================
+# GENERATIVE BUILDING BLOCKS (shared by autoencoder / VAE / GAN / diffusion / U-Net)
+# ============================================================================
+
+class ConvEncoder(nnx.Module):
+    """Downsampling conv stack: (B, H, W, in_ch) -> (B, H/4, W/4, base*2).
+
+    Two stride-2 conv blocks. For a 28x28 input the spatial output is 7x7.
+    """
+
+    def __init__(self, in_channels: int = 1, base: int = 16, *, rngs: nnx.Rngs):
+        self.conv1 = nnx.Conv(in_channels, base, kernel_size=(3, 3),
+                              strides=(2, 2), padding='SAME', rngs=rngs)      # H -> H/2
+        self.conv2 = nnx.Conv(base, base * 2, kernel_size=(3, 3),
+                              strides=(2, 2), padding='SAME', rngs=rngs)      # H/2 -> H/4
+
+    def __call__(self, x, train: bool = False):
+        x = nnx.relu(self.conv1(x))
+        x = nnx.relu(self.conv2(x))
+        return x
+
+
+class ConvDecoder(nnx.Module):
+    """Upsampling ConvTranspose stack mirroring ConvEncoder.
+
+    Maps a latent vector -> (B, out_h, out_w, out_channels) LOGITS (no final
+    activation, so callers can use sigmoid-BCE for images). For out_h=out_w=28
+    the latent is projected to 7x7 then upsampled 7 -> 14 -> 28.
+    """
+
+    def __init__(self, latent_dim: int, base: int = 16, out_channels: int = 1,
+                 start_hw: int = 7, *, rngs: nnx.Rngs):
+        self.base = base
+        self.start_hw = start_hw
+        self.fc = nnx.Linear(latent_dim, base * 2 * start_hw * start_hw, rngs=rngs)
+        self.deconv1 = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                         strides=(2, 2), padding='SAME', rngs=rngs)  # 7 -> 14
+        self.deconv2 = nnx.ConvTranspose(base, out_channels, kernel_size=(3, 3),
+                                         strides=(2, 2), padding='SAME', rngs=rngs)  # 14 -> 28
+
+    def __call__(self, z, train: bool = False):
+        h = nnx.relu(self.fc(z))
+        h = h.reshape(z.shape[0], self.start_hw, self.start_hw, self.base * 2)
+        h = nnx.relu(self.deconv1(h))
+        return self.deconv2(h)   # logits

--- a/examples/shared/training_utils.py
+++ b/examples/shared/training_utils.py
@@ -293,3 +293,18 @@ def create_optimizer(
     
     # Use wrt parameter for newer Flax versions
     return nnx.Optimizer(model, tx, wrt=nnx.Param)
+
+
+# ============================================================================
+# GENERATIVE LOSSES (shared by autoencoder / VAE / diffusion)
+# ============================================================================
+
+def bce_loss(logits: jax.Array, targets: jax.Array) -> jax.Array:
+    """Mean per-example sigmoid binary cross-entropy (summed over pixels)."""
+    per_pixel = optax.sigmoid_binary_cross_entropy(logits, targets)
+    return per_pixel.reshape(per_pixel.shape[0], -1).sum(axis=-1).mean()
+
+
+def kl_divergence(mu: jax.Array, logvar: jax.Array) -> jax.Array:
+    """KL(N(mu, sigma^2) || N(0, I)), averaged over the batch (closed form)."""
+    return (-0.5 * jnp.sum(1.0 + logvar - mu ** 2 - jnp.exp(logvar), axis=-1)).mean()

--- a/examples/vision/__init__.py
+++ b/examples/vision/__init__.py
@@ -1,0 +1,1 @@
+"""vision examples."""

--- a/examples/vision/unet_segmentation.py
+++ b/examples/vision/unet_segmentation.py
@@ -1,0 +1,236 @@
+"""
+U-Net Semantic Segmentation on Synthetic Shapes with Flax NNX
+=============================================================
+A full encoder-decoder U-Net that labels every pixel: two downsampling stages,
+a bottleneck, and a mirrored decoder that upsamples with nnx.ConvTranspose while
+concatenating encoder features through skip connections. Data is generated on the
+fly (random circles/squares + binary masks) so it runs offline on CPU.
+
+Run: python vision/unet_segmentation.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.training_utils import bce_loss
+
+
+# ==== MODEL ====
+
+class DoubleConv(nnx.Module):
+    """(Conv -> GroupNorm -> ReLU) x 2 at a fixed spatial resolution.
+
+    The two-conv block is the basic building unit of U-Net. GroupNorm (not
+    BatchNorm) keeps normalization batch-independent, which plays nicely with
+    `nnx.jit` and small CPU batches. Channel counts must stay divisible by
+    `num_groups`.
+    """
+
+    def __init__(self, in_ch: int, out_ch: int, *, num_groups: int = 8,
+                 rngs: nnx.Rngs):
+        self.conv1 = nnx.Conv(in_ch, out_ch, kernel_size=(3, 3),
+                              padding='SAME', rngs=rngs)
+        self.norm1 = nnx.GroupNorm(out_ch, num_groups=num_groups, rngs=rngs)
+        self.conv2 = nnx.Conv(out_ch, out_ch, kernel_size=(3, 3),
+                              padding='SAME', rngs=rngs)
+        self.norm2 = nnx.GroupNorm(out_ch, num_groups=num_groups, rngs=rngs)
+
+    def __call__(self, x):
+        x = nnx.relu(self.norm1(self.conv1(x)))
+        x = nnx.relu(self.norm2(self.conv2(x)))
+        return x
+
+
+class UNet(nnx.Module):
+    """A 2-level U-Net for binary semantic segmentation.
+
+    Encoder halves the resolution twice (max-pool), the bottleneck runs at the
+    coarsest scale, and the decoder upsamples back with `nnx.ConvTranspose`. At
+    each decoder stage the upsampled features are CONCATENATED with the matching
+    encoder features (the skip connections) before another DoubleConv. Output is
+    per-pixel logits of shape (B, H, W, out_channels) at the input resolution.
+
+    Spatial trace for a 32x32 input:
+      x   (B,32,32,in)
+      s1 = enc1(x)                 -> (B,32,32,base)      [skip 1]
+      s2 = enc2(pool(s1))          -> (B,16,16,base*2)    [skip 2]
+      b  = bottleneck(pool(s2))    -> (B, 8, 8,base*4)
+      up2(b) ++ s2 -> dec2         -> (B,16,16,base*2)
+      up1     ++ s1 -> dec1        -> (B,32,32,base)
+      out_conv                     -> (B,32,32,out)       logits
+    """
+
+    def __init__(self, in_channels: int = 1, out_channels: int = 1,
+                 base: int = 16, *, rngs: nnx.Rngs):
+        # --- Encoder (contracting path) ---
+        self.enc1 = DoubleConv(in_channels, base, rngs=rngs)       # full res
+        self.enc2 = DoubleConv(base, base * 2, rngs=rngs)          # 1/2 res
+
+        # --- Bottleneck ---
+        self.bottleneck = DoubleConv(base * 2, base * 4, rngs=rngs)  # 1/4 res
+
+        # --- Decoder (expanding path) ---
+        # ConvTranspose doubles the resolution; the following DoubleConv sees the
+        # upsampled features concatenated with the encoder skip (hence 2x in_ch).
+        self.up2 = nnx.ConvTranspose(base * 4, base * 2, kernel_size=(3, 3),
+                                     strides=(2, 2), padding='SAME', rngs=rngs)
+        self.dec2 = DoubleConv(base * 4, base * 2, rngs=rngs)      # concat -> base*4
+        self.up1 = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                     strides=(2, 2), padding='SAME', rngs=rngs)
+        self.dec1 = DoubleConv(base * 2, base, rngs=rngs)         # concat -> base*2
+
+        # 1x1 conv projects to per-pixel class logits (no activation).
+        self.out_conv = nnx.Conv(base, out_channels, kernel_size=(1, 1),
+                                 rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        # Encoder: keep s1, s2 as skip sources BEFORE each downsample.
+        s1 = self.enc1(x)                                        # (B,H,  W,  base)
+        s2 = self.enc2(nnx.max_pool(s1, (2, 2), strides=(2, 2)))  # (B,H/2,W/2,base*2)
+        b = self.bottleneck(nnx.max_pool(s2, (2, 2), strides=(2, 2)))  # (B,H/4,...,base*4)
+
+        # Decoder: upsample, concatenate the skip, then DoubleConv.
+        d2 = self.up2(b)                                         # (B,H/2,W/2,base*2)
+        d2 = self.dec2(jnp.concatenate([d2, s2], axis=-1))       # skip 2
+        d1 = self.up1(d2)                                        # (B,H,  W,  base)
+        d1 = self.dec1(jnp.concatenate([d1, s1], axis=-1))       # skip 1
+
+        return self.out_conv(d1)                                 # (B,H,W,out) logits
+
+
+# ==== METRICS ====
+
+def iou_dice(logits, masks, threshold: float = 0.5, eps: float = 1e-6):
+    """Mean IoU and Dice between thresholded predictions and binary masks.
+
+    IoU  = |P ∩ G| / |P ∪ G|      (a.k.a. Jaccard index)
+    Dice = 2|P ∩ G| / (|P| + |G|) (a.k.a. F1 over pixels)
+    """
+    preds = (jax.nn.sigmoid(logits) > threshold).astype(jnp.float32)
+    axes = (1, 2, 3)
+    inter = jnp.sum(preds * masks, axis=axes)
+    p_area = jnp.sum(preds, axis=axes)
+    g_area = jnp.sum(masks, axis=axes)
+    union = p_area + g_area - inter
+    iou = jnp.mean((inter + eps) / (union + eps))
+    dice = jnp.mean((2.0 * inter + eps) / (p_area + g_area + eps))
+    return iou, dice
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    """One optimization step of per-pixel sigmoid binary cross-entropy.
+
+    L = mean_b  sum_pixels  BCE(sigmoid(logit_p), mask_p)
+    """
+    def loss_fn(model):
+        logits = model(batch['image'], train=True)          # (B, H, W, 1)
+        loss = bce_loss(logits, batch['mask'])              # per-pixel sigmoid BCE
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, logits
+
+
+# ==== DATA ====
+
+def make_dataset(n: int = 128, size: int = 32, max_shapes: int = 3,
+                 seed: int = 0):
+    """Generate (images, masks), each (n, size, size, 1), fully offline.
+
+    Each image gets `max_shapes` bright circles/squares dropped on a dim,
+    slightly noisy background. The mask is 1 wherever any shape covers a pixel.
+    Everything is built with jax.random — no downloads.
+    """
+    key = jax.random.key(seed)
+    k_cy, k_cx, k_r, k_shape, k_noise = jax.random.split(key, 5)
+
+    # Pixel coordinate grid, shared by every image.
+    coords = jnp.arange(size, dtype=jnp.float32)
+    gy, gx = jnp.meshgrid(coords, coords, indexing='ij')     # (size, size)
+
+    margin = 0.18 * size
+    cy = jax.random.uniform(k_cy, (n, max_shapes), minval=margin, maxval=size - margin)
+    cx = jax.random.uniform(k_cx, (n, max_shapes), minval=margin, maxval=size - margin)
+    radius = jax.random.uniform(k_r, (n, max_shapes),
+                                minval=0.09 * size, maxval=0.20 * size)
+    is_circle = jax.random.bernoulli(k_shape, 0.5, (n, max_shapes))
+
+    # Broadcast grid (1,1,H,W) against per-shape params (n,K,1,1) -> (n,K,H,W).
+    dy = gy[None, None] - cy[..., None, None]
+    dx = gx[None, None] - cx[..., None, None]
+    r = radius[..., None, None]
+    circ = (dy ** 2 + dx ** 2) <= r ** 2                      # disk
+    square = (jnp.abs(dy) <= r) & (jnp.abs(dx) <= r)          # axis-aligned box
+    per_shape = jnp.where(is_circle[..., None, None], circ, square)
+
+    mask = jnp.any(per_shape, axis=1).astype(jnp.float32)     # (n, H, W) union
+
+    # Image: dim background + bright foreground + mild Gaussian noise, clipped.
+    noise = 0.05 * jax.random.normal(k_noise, (n, size, size))
+    image = 0.15 + 0.70 * mask + noise
+    image = jnp.clip(image, 0.0, 1.0)
+
+    return image[..., None], mask[..., None]                  # (n,H,W,1) each
+
+
+# ==== MAIN ====
+
+def main():
+    # Run-scale from env with small CPU-friendly defaults; always offline.
+    epochs = int(os.environ.get('EPOCHS', 6))
+    batch = int(os.environ.get('BATCH', 16))
+    size = int(os.environ.get('IMG_SIZE', 32))
+    n_data = int(os.environ.get('N_DATA', 128))
+    base = int(os.environ.get('BASE', 16))
+
+    print("=" * 60)
+    print("U-Net semantic segmentation on synthetic shapes (Flax NNX)")
+    print("=" * 60)
+    print(f"  epochs={epochs}  batch={batch}  size={size}x{size}  n={n_data}")
+
+    images, masks = make_dataset(n=n_data, size=size)
+    fg_frac = float(masks.mean())
+    print(f"  data: images {images.shape}, masks {masks.shape} "
+          f"(foreground {fg_frac*100:.1f}% of pixels)")
+
+    model = UNet(in_channels=1, out_channels=1, base=base, rngs=nnx.Rngs(0))
+    import optax
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    n_params = sum(p.size for p in jax.tree.leaves(nnx.state(model, nnx.Param)))
+    print(f"  parameters: {n_params:,}\n")
+
+    key = jax.random.key(1)
+    steps_per_epoch = max(1, n_data // batch)
+    for epoch in range(1, epochs + 1):
+        key, perm_key = jax.random.split(key)
+        perm = jax.random.permutation(perm_key, n_data)
+        running = 0.0
+        for s in range(steps_per_epoch):
+            idx = perm[s * batch:(s + 1) * batch]
+            b = {'image': images[idx], 'mask': masks[idx]}
+            loss, _ = train_step(model, optimizer, b)
+            running += float(loss)
+        # Full-dataset IoU/Dice at epoch end (eval mode is identical here).
+        logits = model(images, train=False)
+        iou, dice = iou_dice(logits, masks)
+        print(f"  epoch {epoch:2d}/{epochs} | BCE {running/steps_per_epoch:8.2f} "
+              f"| IoU {float(iou):.3f} | Dice {float(dice):.3f}")
+
+    print("\nDone. The decoder's nnx.ConvTranspose layers upsample the mask "
+          "back to full resolution; skips restore fine boundaries.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vision/vit.py
+++ b/examples/vision/vit.py
@@ -1,0 +1,224 @@
+"""
+Vision Transformer (ViT) Classifier on MNIST with Flax NNX
+==========================================================
+Patchify 28x28 images into non-overlapping 7x7 patches, embed each patch,
+prepend a learned CLS token + positional embeddings, run a small transformer
+encoder, and classify from the CLS token. Synthetic (offline) by default.
+
+Run: python vision/vit.py
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from shared.models import TransformerBlock
+from shared.training_utils import compute_cross_entropy_loss, compute_accuracy
+
+
+# ==== PATCH EMBEDDING ====
+
+class PatchEmbed(nnx.Module):
+    """Split an image into non-overlapping patches and linearly embed each one.
+
+    Implemented as a single strided convolution: a kernel of size `patch_size`
+    with stride `patch_size` applies one linear map per patch (this is exactly a
+    per-patch flatten + Linear). For 28x28 with patch=7 the output grid is 4x4,
+    which we flatten into a sequence of 16 patch tokens.
+    """
+
+    def __init__(self, patch_size: int, in_channels: int, dim: int, *, rngs: nnx.Rngs):
+        self.proj = nnx.Conv(
+            in_channels, dim,
+            kernel_size=(patch_size, patch_size),
+            strides=(patch_size, patch_size),
+            padding="VALID",
+            rngs=rngs,
+        )
+
+    def __call__(self, x):
+        x = self.proj(x)                       # (B, H/p, W/p, dim)
+        b, h, w, d = x.shape
+        return x.reshape(b, h * w, d)          # (B, num_patches, dim)
+
+
+# ==== MODEL ====
+
+class ViT(nnx.Module):
+    """A compact Vision Transformer for image classification.
+
+    Pipeline:
+      x            (B, 28, 28, 1)
+      -> PatchEmbed                 -> (B, 16, dim)   # 16 non-overlapping patches
+      -> prepend learned CLS token  -> (B, 17, dim)
+      -> add learned pos embeddings -> (B, 17, dim)
+      -> depth x TransformerBlock   -> (B, 17, dim)   # global attention from layer 1
+      -> LayerNorm + take CLS token -> (B, dim)
+      -> Linear head                -> (B, num_classes) logits
+    """
+
+    def __init__(
+        self,
+        *,
+        image_size: int = 28,
+        patch_size: int = 7,
+        in_channels: int = 1,
+        num_classes: int = 10,
+        dim: int = 64,
+        depth: int = 4,
+        num_heads: int = 4,
+        mlp_dim: int = 128,
+        dropout: float = 0.1,
+        rngs: nnx.Rngs,
+    ):
+        assert image_size % patch_size == 0, "image_size must be divisible by patch_size"
+        num_patches = (image_size // patch_size) ** 2  # 4 * 4 = 16
+
+        self.patch_embed = PatchEmbed(patch_size, in_channels, dim, rngs=rngs)
+
+        # Learned CLS token and positional embeddings, stored as trainable Params.
+        # Small-scale init (0.02) matches the ViT / BERT convention.
+        self.cls_token = nnx.Param(0.02 * jax.random.normal(rngs.params(), (1, 1, dim)))
+        self.pos_embed = nnx.Param(
+            0.02 * jax.random.normal(rngs.params(), (1, num_patches + 1, dim))
+        )
+
+        # A stack of pre-norm transformer encoder blocks. MUST be nnx.List so the
+        # submodules are tracked as a pytree on Flax 0.12.
+        self.blocks = nnx.List([
+            TransformerBlock(
+                d_model=dim,
+                num_heads=num_heads,
+                d_ff=mlp_dim,
+                dropout=dropout,
+                rngs=rngs,
+                causal=False,               # bidirectional: every token sees every token
+            )
+            for _ in range(depth)
+        ])
+
+        self.norm = nnx.LayerNorm(dim, rngs=rngs)
+        self.head = nnx.Linear(dim, num_classes, rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        b = x.shape[0]
+
+        tokens = self.patch_embed(x)                          # (B, num_patches, dim)
+
+        # Prepend the CLS token to every example in the batch.
+        cls = jnp.broadcast_to(self.cls_token[...], (b, 1, tokens.shape[-1]))
+        tokens = jnp.concatenate([cls, tokens], axis=1)       # (B, num_patches+1, dim)
+
+        # Add learned positional embeddings (broadcast over the batch).
+        tokens = tokens + self.pos_embed[...]
+
+        for block in self.blocks:
+            tokens = block(tokens, train=train)               # (B, num_patches+1, dim)
+
+        tokens = self.norm(tokens)
+        cls_out = tokens[:, 0]                                 # (B, dim) — the CLS token
+        return self.head(cls_out)                             # (B, num_classes) logits
+
+
+# ==== TRAIN STEP ====
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    """One gradient step of cross-entropy classification."""
+    def loss_fn(model):
+        logits = model(batch["x"], train=True)                # (B, num_classes)
+        loss = compute_cross_entropy_loss(logits, batch["y"])
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    accuracy = compute_accuracy(logits, batch["y"])
+    return loss, accuracy
+
+
+# ==== DATA ====
+
+def make_dataset(synthetic: bool = True, n: int = 512, num_classes: int = 10, seed: int = 0):
+    """Return (images, labels) with images of shape (n, 28, 28, 1) in [0, 1].
+
+    synthetic=True  -> offline images WITH per-class signal: each class lights up
+                       a distinct 7x7 patch cell of the 4x4 grid, plus Gaussian
+                       noise. This gives a learnable pattern a ViT can pick up in
+                       a few dozen steps (no downloads).
+    synthetic=False -> real MNIST via tfds, scaled to [0, 1].
+    """
+    if synthetic:
+        key = jax.random.key(seed)
+        k_lab, k_noise = jax.random.split(key)
+        labels = jax.random.randint(k_lab, (n,), 0, num_classes)
+
+        # One bright-patch template per class: class c -> grid cell (c // 4, c % 4).
+        grid = 28 // 7  # 4 cells per side, 16 total (covers 10 classes)
+        templates = jnp.zeros((num_classes, 28, 28, 1))
+        for c in range(num_classes):
+            r, col = c // grid, c % grid
+            templates = templates.at[c, r * 7:(r + 1) * 7, col * 7:(col + 1) * 7, 0].set(1.0)
+
+        images = templates[labels] + 0.3 * jax.random.normal(k_noise, (n, 28, 28, 1))
+        images = jnp.clip(images, 0.0, 1.0)
+        return images, labels
+
+    import tensorflow_datasets as tfds
+    import tensorflow as tf
+    tf.config.set_visible_devices([], "GPU")
+    ds = tfds.load("mnist", split=f"train[:{n}]", as_supervised=True)
+    imgs, labs = [], []
+    for img, lab in tfds.as_numpy(ds):
+        imgs.append(img.astype("float32") / 255.0)
+        labs.append(int(lab))
+    return jnp.asarray(imgs).reshape(-1, 28, 28, 1), jnp.asarray(labs)
+
+
+# ==== MAIN ====
+
+def main():
+    # Run-scale from env with small CPU-friendly defaults; SYNTHETIC by default.
+    epochs = int(os.environ.get("EPOCHS", 20))
+    batch = int(os.environ.get("BATCH", 64))
+    synthetic = os.environ.get("SYNTHETIC", "1") != "0"
+    num_classes = 10
+
+    print(f"Vision Transformer on {'synthetic' if synthetic else 'MNIST'} data")
+    print(f"  epochs={epochs} batch={batch}")
+
+    images, labels = make_dataset(synthetic=synthetic, num_classes=num_classes)
+    n = images.shape[0]
+    print(f"  dataset: images {images.shape}, labels {labels.shape}")
+
+    model = ViT(num_classes=num_classes, dim=64, depth=4, num_heads=4, rngs=nnx.Rngs(0))
+    optimizer = nnx.Optimizer(model, optax.adamw(1e-3), wrt=nnx.Param)
+
+    key = jax.random.key(1)
+    step = 0
+    for epoch in range(1, epochs + 1):
+        key, perm_key = jax.random.split(key)
+        order = jax.random.permutation(perm_key, n)
+        ep_loss, ep_acc, nb = 0.0, 0.0, 0
+        for start in range(0, n - batch + 1, batch):
+            idx = order[start:start + batch]
+            b = {"x": images[idx], "y": labels[idx]}
+            loss, acc = train_step(model, optimizer, b)
+            ep_loss += float(loss)
+            ep_acc += float(acc)
+            nb += 1
+            step += 1
+        print(f"  epoch {epoch:2d}/{epochs} | steps {step:4d} | "
+              f"loss {ep_loss / max(nb, 1):.4f} | acc {ep_acc / max(nb, 1):.3f}")
+
+    print("Done. Every patch token attends to every other from the first layer — "
+          "a global receptive field, unlike a CNN's local kernels.")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/docs/applications/adaptation/clip.md
+++ b/website/docs/applications/adaptation/clip.md
@@ -1,0 +1,269 @@
+---
+sidebar_position: 2
+title: Toy CLIP Cross-Modal Contrastive Learning
+description: "Build a tiny CLIP in Flax NNX — align synthetic images and captions in one embedding space with a symmetric InfoNCE loss and batch retrieval accuracy."
+keywords: [CLIP, contrastive learning, cross-modal, InfoNCE, NT-Xent, image-text, flax nnx, jax, retrieval, temperature, dual encoder]
+---
+
+# Toy CLIP: Cross-Modal Contrastive Learning
+
+**Teach an image encoder and a text encoder to agree.** This is CLIP at toy scale — align synthetic "digit-like" images with their captions in one shared embedding space, with no labels beyond "these two go together."
+
+:::note Prerequisites
+This sits on top of two towers. Comfortable with a [simple CNN](/basics/vision/simple-cnn) for the image side and a [simple transformer / embedding](/basics/text/simple-transformer) for the text side? Good. CLIP is a *cross-modal* twist on [contrastive learning](/research/contrastive-learning) — read that first for the single-modality (SimCLR) version.
+:::
+
+:::tip What you'll learn
+- Why CLIP aligns **two modalities** instead of two augmentations of one (the key difference from SimCLR)
+- Build a **dual encoder**: a CNN image tower and an `nnx.Embed` + mean-pool text tower projecting into a shared space
+- The **symmetric InfoNCE** loss — cross-entropy in both directions with the batch diagonal as the correct pairing
+- Why you **L2-normalize** embeddings and divide by a **temperature**
+- Measure **batch retrieval accuracy** (argmax over each row equals the diagonal) as the task metric
+:::
+
+:::info Example Code
+See the full, verified implementation: [`examples/adaptation/clip_toy.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/adaptation/clip_toy.py)
+:::
+
+## The Motivation
+
+[SimCLR](/research/contrastive-learning) learns image representations by pulling
+together two *augmented views of the same image* and pushing apart different
+images. Everything happens inside **one modality**.
+
+**CLIP** (Contrastive Language–Image Pre-training) changes the positive pair:
+instead of two crops of one photo, the positive pair is *an image and its
+caption* — two **different modalities** describing the same thing. There are no
+hand-crafted augmentations; the "view" of a cat photo is simply the text "a
+photo of a cat." Train on enough image–text pairs and the two encoders converge
+on a **shared embedding space** where matching images and captions land near
+each other, enabling zero-shot classification and cross-modal retrieval.
+
+This page builds that mechanism end to end at a scale that runs on a CPU in
+seconds. Images are synthetic "digit-like" blobs (one fixed pattern per class);
+captions are the template **"a photo of the digit N"** rendered as token ids.
+The learning signal is identical to real CLIP — only the data is tiny.
+
+## The Math
+
+Each tower maps its input to a vector, which we **L2-normalize** so similarity
+is pure cosine similarity. For a batch of $B$ image–caption pairs, let
+$u_i$ be the normalized image embedding and $v_j$ the normalized text embedding.
+The scaled similarity matrix (logits) is
+
+$$
+\ell_{ij} = \frac{u_i^\top v_j}{\tau}, \qquad \|u_i\| = \|v_j\| = 1,
+$$
+
+where $\tau$ is a **temperature** (smaller $\tau$ sharpens the distribution).
+Within a batch, pair $i$'s image should match pair $i$'s caption and *no other*,
+so the correct target for every row is its own index — the **diagonal**. That
+turns the problem into two classification tasks, and CLIP averages both:
+
+$$
+\mathcal{L} = \tfrac{1}{2}\Big(
+\underbrace{-\tfrac{1}{B}\sum_{i} \log \frac{e^{\ell_{ii}}}{\sum_{j} e^{\ell_{ij}}}}_{\text{image}\to\text{text}}
+\;+\;
+\underbrace{-\tfrac{1}{B}\sum_{i} \log \frac{e^{\ell_{ii}}}{\sum_{j} e^{\ell_{ji}}}}_{\text{text}\to\text{image}}
+\Big).
+$$
+
+The first term treats each **image as a query** over the $B$ captions; the
+second treats each **caption as a query** over the $B$ images. This is exactly
+the InfoNCE / NT-Xent objective, made **symmetric** across the two modalities.
+The other $B-1$ entries in each row are in-batch negatives, so a larger batch
+means a harder, more informative task.
+
+## The Model
+
+Two encoders, one shared projection dimension. The image tower reuses the
+shared `ConvEncoder` (a small stride-2 CNN); the text tower embeds tokens and
+mean-pools over the sequence. Both project to `proj_dim` and L2-normalize.
+
+```python
+import jax, jax.numpy as jnp
+from flax import nnx
+import optax
+from shared.models import ConvEncoder
+from shared.training_utils import compute_cross_entropy_loss
+
+class CLIPToy(nnx.Module):
+    def __init__(self, num_classes, *, proj_dim=64, embed_dim=64,
+                 img_size=28, base=16, temperature=0.07, rngs: nnx.Rngs):
+        self.temperature = temperature  # static float, baked into jit
+
+        # Image tower: ConvEncoder halves H,W twice -> img_size/4 spatial.
+        self.image_encoder = ConvEncoder(in_channels=1, base=base, rngs=rngs)
+        feat_hw = img_size // 4
+        self.image_proj = nnx.Linear(base * 2 * feat_hw * feat_hw, proj_dim, rngs=rngs)
+
+        # Text tower: token embedding + mean-pool + projection.
+        self.token_embed = nnx.Embed(vocab_size(num_classes), embed_dim, rngs=rngs)
+        self.text_proj = nnx.Linear(embed_dim, proj_dim, rngs=rngs)
+
+    @staticmethod
+    def _l2_normalize(x):
+        return x / (jnp.linalg.norm(x, axis=-1, keepdims=True) + 1e-8)
+
+    def encode_image(self, images):
+        h = self.image_encoder(images)                 # (B, H/4, W/4, base*2)
+        h = h.reshape((h.shape[0], -1))                # flatten
+        return self._l2_normalize(self.image_proj(h))  # (B, proj_dim)
+
+    def encode_text(self, tokens):
+        emb = self.token_embed(tokens).mean(axis=1)     # embed + mean-pool
+        return self._l2_normalize(self.text_proj(emb))  # (B, proj_dim)
+
+    def __call__(self, images, tokens):
+        return self.encode_image(images), self.encode_text(tokens)
+```
+
+Only the final token of each caption varies with the class, so the text tower
+must learn to route that discriminative digit token through the mean-pool. Note
+CLIP uses a *learnable* temperature (a `log`-scale `nnx.Param`); we keep it a
+fixed float here so the toy's loss curve stays clean and reproducible.
+
+### The captions and images
+
+Captions follow a single template, so the vocabulary is five shared words plus
+one distinct token per digit:
+
+```python
+_TEMPLATE_WORDS = ["a", "photo", "of", "the", "digit"]
+SEQ_LEN = len(_TEMPLATE_WORDS) + 1
+
+def vocab_size(num_classes):
+    return len(_TEMPLATE_WORDS) + num_classes
+
+def build_captions(num_classes):
+    template = jnp.broadcast_to(jnp.arange(len(_TEMPLATE_WORDS)),
+                                (num_classes, len(_TEMPLATE_WORDS)))
+    digit_tokens = len(_TEMPLATE_WORDS) + jnp.arange(num_classes)
+    return jnp.concatenate([template, digit_tokens[:, None]], axis=1)
+```
+
+Each batch samples **distinct** classes so the diagonal is the *unique* correct
+pairing — that keeps batch retrieval accuracy an honest signal (two identical
+captions in one batch would make the target ambiguous).
+
+## The Symmetric InfoNCE Loss
+
+The loss is the two-directional cross-entropy from the math above. Because the
+correct label for row $i$ is $i$, the targets are just `arange(B)`:
+
+```python
+def clip_loss(img_emb, txt_emb, temperature):
+    logits = (img_emb @ txt_emb.T) / temperature          # (B, B)
+    labels = jnp.arange(img_emb.shape[0])
+    loss_i2t = compute_cross_entropy_loss(logits, labels)      # image -> text
+    loss_t2i = compute_cross_entropy_loss(logits.T, labels)    # text  -> image
+    return 0.5 * (loss_i2t + loss_t2i)
+
+def retrieval_accuracy(img_emb, txt_emb):
+    sims = img_emb @ txt_emb.T
+    labels = jnp.arange(img_emb.shape[0])
+    acc_i2t = jnp.mean(jnp.argmax(sims, axis=1) == labels)     # image -> text
+    acc_t2i = jnp.mean(jnp.argmax(sims, axis=0) == labels)     # text  -> image
+    return 0.5 * (acc_i2t + acc_t2i)
+```
+
+## The Train Step
+
+Standard NNX training: differentiate the loss, return the retrieval accuracy as
+aux, and let the optimizer update all parameters.
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        img_emb = model.encode_image(batch["image"])
+        txt_emb = model.encode_text(batch["tokens"])
+        loss = clip_loss(img_emb, txt_emb, model.temperature)
+        acc = retrieval_accuracy(img_emb, txt_emb)
+        return loss, acc
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+model = CLIPToy(num_classes=10, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+## Results / What to Expect
+
+The defaults are offline and synthetic. On CPU the loss collapses toward zero
+within ~50 steps and **batch retrieval accuracy reaches 1.0** — every image
+retrieves its own caption and vice versa:
+
+```console
+$ python adaptation/clip_toy.py
+============================================================
+Toy CLIP — cross-modal contrastive learning
+============================================================
+classes=10  vocab=15  seq_len=6  batch=8  synthetic=True
+trainable params: 110336
+
+[train] 1 epoch(s) x 300 steps
+  epoch 0 step   0 | loss 2.3067 | retrieval acc 0.062
+  epoch 0 step  50 | loss 0.0004 | retrieval acc 1.000
+  epoch 0 step 100 | loss 0.0001 | retrieval acc 1.000
+  epoch 0 step 150 | loss 0.0001 | retrieval acc 1.000
+  epoch 0 step 200 | loss 0.0000 | retrieval acc 1.000
+  epoch 0 step 250 | loss 0.0000 | retrieval acc 1.000
+
+[assertions]
+  loss decreased:      0.0000 < 2.3067 -> True
+  retrieval improved:  1.000 > 0.062 -> True
+```
+
+For a contrastive objective the scalar loss is only half the story — the signal
+that matters is the **task metric**, retrieval accuracy, climbing from chance
+($1/B$) to 1.0. Set `SYNTHETIC=0` to swap the synthetic blobs for per-class mean
+MNIST images (falls back to synthetic if MNIST cannot be loaded offline), or
+tune `BATCH`, `STEPS`, and `NUM_CLASSES` via environment variables.
+
+## Common Pitfalls
+
+- ❌ Skipping L2-normalization and feeding raw embeddings into the dot product.
+  Logit magnitudes then depend on vector norms, and the temperature stops meaning
+  anything.
+  ✅ Normalize both towers to unit length so logits are true cosine similarities.
+
+- ❌ Using a one-directional cross-entropy (image→text only). The text tower gets
+  a weaker gradient and alignment is lopsided.
+  ✅ Average **both** directions: `0.5 * (loss_i2t + loss_t2i)` on `logits` and `logits.T`.
+
+- ❌ Letting duplicate classes into a batch, then trusting retrieval accuracy.
+  Two identical captions make the diagonal target ambiguous and the metric lies.
+  ✅ Sample **distinct** classes per batch so the diagonal is the unique positive.
+
+- ❌ Treating this like SimCLR and augmenting one modality into two views.
+  CLIP's positive pair is *cross-modal* (image ↔ caption), not two crops.
+  ✅ Keep one image encoder and one text encoder; the caption *is* the second view.
+
+- ❌ Setting the temperature far too high (e.g. $\tau=1$) with normalized vectors.
+  Logits are capped at $\pm 1$, the softmax barely separates positives, and
+  learning crawls.
+  ✅ Use a small $\tau$ (CLIP uses ~0.07) — or make it a learnable `log`-scale param.
+
+## Next steps
+
+- [Contrastive Learning with SimCLR](/research/contrastive-learning) — the
+  single-modality cousin: same InfoNCE math, but positives are augmentations.
+- [LoRA Parameter-Efficient Fine-Tuning](/applications/adaptation/lora-finetuning)
+  — once you have a pretrained encoder, adapt it to new tasks with tiny adapters.
+
+## Complete Example
+
+The full, verified script is at
+[`examples/adaptation/clip_toy.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/adaptation/clip_toy.py)
+— a CPU-friendly, offline toy CLIP with synthetic image–caption defaults, a
+symmetric InfoNCE loss, batch retrieval-accuracy reporting, and an optional
+MNIST-prototype mode (`SYNTHETIC=0`) that degrades gracefully offline.
+
+## References
+
+- Radford et al., *Learning Transferable Visual Models From Natural Language Supervision* (CLIP, 2021). [arXiv:2103.00020](https://arxiv.org/abs/2103.00020)
+- Oord, Li & Vinyals, *Representation Learning with Contrastive Predictive Coding* (InfoNCE, 2018). [arXiv:1807.03748](https://arxiv.org/abs/1807.03748)
+- Chen et al., *A Simple Framework for Contrastive Learning of Visual Representations* (SimCLR, 2020). [arXiv:2002.05709](https://arxiv.org/abs/2002.05709)
+- Jia et al., *Scaling Up Visual and Vision-Language Representation Learning With Noisy Text Supervision* (ALIGN, 2021). [arXiv:2102.05918](https://arxiv.org/abs/2102.05918)

--- a/website/docs/applications/adaptation/index.md
+++ b/website/docs/applications/adaptation/index.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 0
+title: Multimodal & Adaptation in Flax NNX
+description: Parameter-efficient fine-tuning with LoRA and cross-modal models in Flax NNX — adapt frozen models with nnx.LoRALinear and train under 1% of parameters.
+keywords: [LoRA, fine-tuning, PEFT, parameter-efficient, multimodal, CLIP, flax nnx, jax, nnx.LoRALinear]
+---
+
+# Multimodal & Adaptation
+
+Training from scratch is expensive. This track is about **reusing and adapting**
+models — attaching small trainable adapters to a frozen network, and aligning
+models across different modalities (like images and text).
+
+## What you'll build
+
+- **[LoRA Fine-Tuning](/applications/adaptation/lora-finetuning)** — freeze a full
+  model and train only tiny low-rank adapters (`nnx.LoRALinear`), updating well
+  under 1% of the parameters. Uses `nnx.Optimizer(wrt=nnx.LoRAParam)` to scope
+  training to just the adapters.
+
+A cross-modal (CLIP-style image-text) guide is on the way.
+
+## Prerequisites
+
+You should have built a [transformer](/basics/text/simple-transformer) (the model
+we adapt) and understand [Flax NNX state and parameter filtering](/basics/fundamentals/understanding-state).
+
+## Next steps
+
+- Build [LoRA Fine-Tuning](/applications/adaptation/lora-finetuning).
+- Contrast with [Knowledge Distillation](/research/knowledge-distillation), a
+  different efficiency approach (compress into a smaller student).

--- a/website/docs/applications/adaptation/index.md
+++ b/website/docs/applications/adaptation/index.md
@@ -17,8 +17,8 @@ models across different modalities (like images and text).
   model and train only tiny low-rank adapters (`nnx.LoRALinear`), updating well
   under 1% of the parameters. Uses `nnx.Optimizer(wrt=nnx.LoRAParam)` to scope
   training to just the adapters.
-
-A cross-modal (CLIP-style image-text) guide is on the way.
+- **[CLIP (toy)](/applications/adaptation/clip)** — align an image encoder and a
+  text encoder in a shared embedding space with a symmetric contrastive loss.
 
 ## Prerequisites
 

--- a/website/docs/applications/adaptation/lora-finetuning.md
+++ b/website/docs/applications/adaptation/lora-finetuning.md
@@ -1,0 +1,251 @@
+---
+sidebar_position: 1
+title: LoRA Parameter-Efficient Fine-Tuning in Flax NNX
+description: "Fine-tune a frozen Flax NNX model by training only low-rank adapters with nnx.LoRALinear and nnx.LoRAParam — base weights stay frozen, bit-identical."
+keywords: [LoRA, parameter-efficient fine-tuning, PEFT, low-rank adaptation, nnx.LoRALinear, nnx.LoRAParam, flax nnx, jax, frozen weights, DiffState]
+---
+
+# LoRA Parameter-Efficient Fine-Tuning
+
+Adapt a pretrained model to a new task by training only tiny low-rank adapters while every base weight stays frozen — bit-for-bit unchanged.
+
+:::note Prerequisites
+This builds on the models you adapt and on Flax NNX state filtering. Comfortable
+with a [transformer / MLP](/basics/text/simple-transformer) and with
+[state and parameter filtering](/basics/fundamentals/understanding-state)? Good.
+LoRA is a *different* efficiency lever than
+[knowledge distillation](/research/knowledge-distillation) — this page contrasts them.
+:::
+
+:::tip What you'll learn
+- Why low-rank updates $W' = W + \tfrac{\alpha}{r}BA$ can fine-tune a model with a tiny fraction of the parameters
+- Attach adapters with `nnx.LoRALinear` and scope training to `nnx.LoRAParam`
+- Why adapter-only training needs **both** `nnx.Optimizer(..., wrt=nnx.LoRAParam)` **and** `nnx.value_and_grad(..., argnums=nnx.DiffState(0, nnx.LoRAParam))`
+- Filter frozen base weights with the intersection `nnx.All(nnx.Param, nnx.Not(nnx.LoRAParam))`
+- Prove the base is frozen (bit-identical before/after) while adapters learn a new task
+:::
+
+:::info Example Code
+See the full, verified implementation: [`examples/adaptation/lora_finetuning.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/adaptation/lora_finetuning.py)
+:::
+
+## The Motivation
+
+Fully fine-tuning a large model means updating — and storing a fresh copy of —
+*every* weight for *every* downstream task. For a model with billions of
+parameters that is expensive to train and wasteful to serve: one 10 GB checkpoint
+per task.
+
+**LoRA (Low-Rank Adaptation)** takes a different route. Freeze the pretrained
+weights entirely and inject a small, trainable, low-rank update alongside each
+weight matrix. You train only the adapters — often **well under 1%** of the
+parameters — and ship a few megabytes per task instead of a full checkpoint.
+
+Contrast this with [knowledge distillation](/research/knowledge-distillation),
+the other efficiency lever: distillation *compresses* knowledge into a smaller
+student network (a new, cheaper model), whereas LoRA *keeps the original model
+intact* and bolts on cheap, swappable adapters. Distillation changes the model;
+LoRA changes almost nothing about it.
+
+## The Math
+
+A pretrained linear layer computes $h = Wx$ with a frozen weight matrix
+$W \in \mathbb{R}^{d_\text{out} \times d_\text{in}}$. LoRA hypothesizes that the
+*update* needed to adapt to a new task has low intrinsic rank, so it constrains
+the change to a rank-$r$ factorization:
+
+$$
+W' = W + \Delta W = W + \frac{\alpha}{r}\, B A,
+\qquad B \in \mathbb{R}^{d_\text{out} \times r},\;
+A \in \mathbb{R}^{r \times d_\text{in}},\; r \ll \min(d_\text{in}, d_\text{out}).
+$$
+
+Only $A$ and $B$ are trained; $W$ never moves. The scalar $\alpha/r$ scales the
+update. At initialization $B = 0$ (and $A$ is small random), so $\Delta W = 0$
+and the adapted model starts out **identical** to the pretrained one — training
+can only improve from the pretrained baseline.
+
+**Why "under 1%"?** A full weight matrix has $d_\text{in} \cdot d_\text{out}$
+parameters; the adapter has $r\,(d_\text{in} + d_\text{out})$. For a
+$4096 \times 4096$ attention projection with $r = 8$ that is
+$8 \cdot 8192 = 65{,}536$ adapter params versus $16.7$M base params — about
+**0.4%**. The savings grow as the matrices get bigger. (In the toy
+$\mathbb{R}^8 \to \mathbb{R}^4$ model below the matrices are *tiny*, so the
+adapters are a large fraction — the effect is illustrative, not the payoff.)
+
+Flax's `nnx.LoRALinear` implements exactly this: it holds the frozen base kernel
+as an `nnx.Param` and the factors $A, B$ as `nnx.LoRAParam`, and its forward pass
+is $y = Wx + (xA)B$ with $B$ initialized to zero.
+
+## The Model
+
+`nnx.LoRALinear` is a drop-in for `nnx.Linear` that carries adapters. Stack two
+of them into an MLP:
+
+```python
+import jax, jax.numpy as jnp
+from flax import nnx
+import optax
+
+class LoRAMLP(nnx.Module):
+    def __init__(self, in_dim, hidden, out_dim, rank, *, rngs: nnx.Rngs):
+        self.l1 = nnx.LoRALinear(in_dim, hidden, lora_rank=rank, rngs=rngs)
+        self.l2 = nnx.LoRALinear(hidden, out_dim, lora_rank=rank, rngs=rngs)
+
+    def __call__(self, x):
+        return self.l2(nnx.relu(self.l1(x)))
+```
+
+Each `LoRALinear` splits into two kinds of variables. `nnx.LoRAParam` is a
+**subclass** of `nnx.Param`, which is the crux of everything below: a naive
+"train all `nnx.Param`" filter would sweep in the adapters *and* the base. To
+select only the frozen base, take the intersection of "is a Param" and "is not a
+LoRAParam":
+
+```python
+# Frozen base weights = Param AND (NOT LoRAParam).
+# Use nnx.All (intersection). The comma form nnx.state(m, A, B) returns TWO
+# states, which is not what we want here.
+BASE_PARAMS = nnx.All(nnx.Param, nnx.Not(nnx.LoRAParam))
+
+def count_params(model, filt):
+    return int(sum(x.size for x in jax.tree.leaves(nnx.state(model, filt))))
+```
+
+## Pretrain, Then Freeze and Adapt
+
+The narrative: **pretrain** the whole model on task A (a random linear map),
+then **freeze** it and **adapt** to task B (the same inputs, but a rotated and
+shifted target — a domain shift) by training *only* the adapters.
+
+### Phase 1 — full fine-tuning on task A
+
+Standard training with `wrt=nnx.Param` updates everything (base + adapters):
+
+```python
+@nnx.jit
+def pretrain_step(model, optimizer, batch):
+    def loss_fn(model):
+        preds = model(batch['x'])
+        loss = jnp.mean((preds - batch['y']) ** 2)
+        return loss, preds
+    (loss, preds), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, preds
+
+model = LoRAMLP(8, 64, 4, rank=4, rngs=nnx.Rngs(0))
+pre_opt = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)  # trains all
+```
+
+### Phase 2 — adapter-only fine-tuning on task B
+
+Now freeze the base. Adapter-only training requires **two** changes that must
+agree, because `LoRAParam` is a subclass of `Param`:
+
+1. Build the optimizer with `wrt=nnx.LoRAParam` so it only holds/updates adapter state.
+2. Restrict the gradient to the adapter subtree with `argnums=nnx.DiffState(0, nnx.LoRAParam)`.
+
+```python
+@nnx.jit
+def adapt_step(model, optimizer, batch):
+    def loss_fn(model):
+        preds = model(batch['x'])
+        loss = jnp.mean((preds - batch['y']) ** 2)
+        return loss, preds
+    (loss, preds), grads = nnx.value_and_grad(
+        loss_fn,
+        argnums=nnx.DiffState(0, nnx.LoRAParam),  # gradient only w.r.t. adapters
+        has_aux=True,
+    )(model)
+    optimizer.update(model, grads)
+    return loss, preds
+
+adapt_opt = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.LoRAParam)  # adapters only
+```
+
+If you set only one of the two (e.g. keep the default `wrt=nnx.Param`), the base
+weights *will* move — LoRA's whole promise silently breaks. To make the freeze a
+checked invariant, snapshot the base before and after:
+
+```python
+def snapshot(model, filt):
+    return jax.tree.map(lambda a: jnp.array(a), nnx.state(model, filt))
+
+base_before = snapshot(model, BASE_PARAMS)
+# ... run adapt_step in a loop on task B ...
+base_after = snapshot(model, BASE_PARAMS)
+assert all(bool(jnp.array_equal(x, y))
+           for x, y in zip(jax.tree.leaves(base_before),
+                           jax.tree.leaves(base_after)))  # bit-identical
+```
+
+## Results / What to Expect
+
+Running the example on CPU (defaults are offline and synthetic) prints the
+parameter split, drives task-A MSE to near zero, then adapts to the shifted
+task B using only the adapters — while the base stays bit-identical:
+
+```console
+$ python adaptation/lora_finetuning.py
+Base (frozen) params : 836
+LoRA (trainable) params: 560  (40.1% of total)
+
+[pretrain task A]
+  epoch 0: task-A MSE = 0.0051
+
+[adapt task B — LoRA only]
+  epoch 0: task-B MSE = 0.0641
+
+[assertions]
+  task-B MSE decreased: 0.0641 < 21.1328 -> True
+  base weights bit-identical: True
+  LoRA weights changed: True
+```
+
+Task-B loss falls from ~21 to ~0.06 by moving **only** the 560 adapter values;
+the 836 base parameters are frozen to the bit. (Remember: the 40% adapter share
+is an artifact of the tiny $8 \to 64 \to 4$ layers; on a real large model the same
+recipe puts the adapters well under 1%.)
+
+## Common Pitfalls
+
+- ❌ `nnx.Optimizer(model, tx, wrt=nnx.Param)` for adapter-only training.
+  Since `nnx.LoRAParam` **is** an `nnx.Param`, this trains the base too.
+  ✅ Use `wrt=nnx.LoRAParam` **and** `argnums=nnx.DiffState(0, nnx.LoRAParam)` — both.
+
+- ❌ Setting `wrt=nnx.LoRAParam` on the optimizer but leaving the gradient as the
+  default (differentiates all params). The optimizer only *applies* to adapters,
+  but you still pay to compute base gradients — and a shape mismatch can bite.
+  ✅ Match them: scope the gradient with `nnx.DiffState(0, nnx.LoRAParam)`.
+
+- ❌ Filtering the base with the comma form `nnx.state(m, nnx.Param, nnx.Not(nnx.LoRAParam))`,
+  expecting the frozen weights. That returns **two** separate states.
+  ✅ Take the intersection: `nnx.All(nnx.Param, nnx.Not(nnx.LoRAParam))`.
+
+- ❌ Expecting the adapted model to differ from the pretrained one at step 0.
+  With $B = 0$, $\Delta W = 0$ and outputs are identical until you train.
+  ✅ That's by design — LoRA starts from the pretrained baseline and can only add.
+
+- ❌ Assuming LoRA always saves ">99%" regardless of shape. On small matrices
+  $r(d_\text{in}+d_\text{out})$ can rival $d_\text{in}\,d_\text{out}$.
+  ✅ The savings scale with matrix size; pick $r \ll \min(d_\text{in}, d_\text{out})$.
+
+## Next steps
+
+- [Knowledge Distillation](/research/knowledge-distillation) — the complementary
+  efficiency lever: compress into a smaller student instead of freezing and adapting.
+- [Variational Autoencoders (VAE)](/applications/generative/vae) — more practice
+  with custom `nnx.value_and_grad` training loops and losses.
+
+## Complete Example
+
+The full, verified script is at
+[`examples/adaptation/lora_finetuning.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/adaptation/lora_finetuning.py)
+— a CPU-friendly, offline LoRA demo with synthetic-regression defaults, a
+pretrain→freeze→adapt loop, parameter-count reporting, and frozen-base assertions.
+
+## References
+
+- Hu et al., *LoRA: Low-Rank Adaptation of Large Language Models* (2021). [arXiv:2106.09685](https://arxiv.org/abs/2106.09685)
+- Aghajanyan, Zettlemoyer & Gupta, *Intrinsic Dimensionality Explains the Effectiveness of Language Model Fine-Tuning* (2020). [arXiv:2012.13255](https://arxiv.org/abs/2012.13255)
+- Dettmers et al., *QLoRA: Efficient Finetuning of Quantized LLMs* (2023). [arXiv:2305.14314](https://arxiv.org/abs/2305.14314)

--- a/website/docs/applications/generative/autoencoder.md
+++ b/website/docs/applications/generative/autoencoder.md
@@ -1,0 +1,202 @@
+---
+sidebar_position: 1
+title: Convolutional Autoencoder & Denoising in Flax NNX
+description: "Build a convolutional autoencoder in Flax NNX: compress MNIST through a latent bottleneck and reconstruct with nnx.ConvTranspose, plus a denoising variant."
+keywords: [autoencoder, denoising autoencoder, flax nnx, jax, ConvTranspose, bottleneck, MNIST, representation learning]
+---
+
+# Convolutional Autoencoder
+
+Squeeze an image through a tiny latent bottleneck, then rebuild it — the simplest way to learn what a network chooses to *keep*.
+
+:::note Prerequisites
+This guide builds on [Simple CNN](/basics/vision/simple-cnn) for the encoder and [Simple Training Loop](/basics/workflows/simple-training) for the optimization pattern.
+:::
+
+:::tip What you'll learn
+- Build an encoder → bottleneck → decoder in Flax NNX by reusing shared `ConvEncoder` and `ConvDecoder`
+- Use `nnx.ConvTranspose` to *learn* upsampling instead of fixed interpolation
+- Train with a per-pixel sigmoid binary cross-entropy reconstruction loss
+- Turn the same model into a **denoising** autoencoder by corrupting the input while keeping a clean target
+- Track tensor shapes through the 28 → 7 → 28 bottleneck without flatten bugs
+:::
+
+:::info Example Code
+Full runnable script: [`examples/generative/autoencoder.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/autoencoder.py)
+:::
+
+## Why autoencoders?
+
+An autoencoder learns to copy its input to its output — but through a narrow **bottleneck** that is far smaller than the input. Because the code $z$ cannot hold all 784 pixels of a 28×28 image, the network is forced to keep only the structure that matters for reconstruction and throw away noise. That pressure is what makes the latent code a useful, compressed representation.
+
+Formally, we split the model into an encoder $f_\theta$ and a decoder $g_\phi$:
+
+$$
+z = f_\theta(x) \in \mathbb{R}^d, \qquad \hat{x} = g_\phi(z), \qquad d \ll 784.
+$$
+
+We train both halves jointly to minimize a **reconstruction loss** between the original $x$ and the reconstruction $\hat{x}$. For images with pixel values in $[0, 1]$, the decoder emits logits and we use per-pixel sigmoid binary cross-entropy, summed over pixels and averaged over the batch:
+
+$$
+\mathcal{L}(x) = -\sum_{i} \Big[\, x_i \log \sigma(\ell_i) + (1 - x_i)\log\big(1 - \sigma(\ell_i)\big)\Big],
+\qquad \hat{x}_i = \sigma(\ell_i),
+$$
+
+where $\ell_i$ is the decoder's output logit for pixel $i$ and $\sigma$ is the sigmoid. BCE is the natural choice when targets live in $[0, 1]$: it treats each pixel as a Bernoulli probability.
+
+### Why ConvTranspose upsamples
+
+The encoder uses two stride-2 convolutions that **halve** the spatial size twice: $28 \to 14 \to 7$. To reconstruct, the decoder must go the other way, $7 \to 14 \to 28$. A transposed convolution (`nnx.ConvTranspose`) with stride 2 does exactly this: it spreads each input cell across a larger output window and *learns* the upsampling kernel, rather than relying on a fixed rule like nearest-neighbor or bilinear interpolation. Stacking two of them mirrors the encoder and returns to full resolution.
+
+## Building the model
+
+We reuse the shared `ConvEncoder` (two stride-2 conv blocks) and `ConvDecoder` (a linear projection plus two `nnx.ConvTranspose` blocks), and add a `nnx.Linear` **bottleneck** in between.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+from shared.models import ConvEncoder, ConvDecoder
+from shared.training_utils import bce_loss
+
+
+class ConvAutoencoder(nnx.Module):
+    """Encoder -> Linear bottleneck -> Decoder."""
+
+    def __init__(self, latent_dim: int = 32, base: int = 16,
+                 in_channels: int = 1, *, rngs: nnx.Rngs):
+        self.enc_hw = 7                      # 28 -> 14 -> 7 after two stride-2 convs
+        self.enc_channels = base * 2         # ConvEncoder doubles `base`
+        self.encoder = ConvEncoder(in_channels, base, rngs=rngs)
+        # Bottleneck: squeeze the (7*7*base*2) feature map into `latent_dim`.
+        self.bottleneck = nnx.Linear(
+            self.enc_channels * self.enc_hw * self.enc_hw, latent_dim, rngs=rngs
+        )
+        # Decoder mirrors the encoder and returns LOGITS (no final activation).
+        self.decoder = ConvDecoder(latent_dim, base, in_channels,
+                                   start_hw=self.enc_hw, rngs=rngs)
+
+    def encode(self, x):
+        h = self.encoder(x)                  # (B, 7, 7, base*2)
+        h = h.reshape(h.shape[0], -1)        # (B, 7*7*base*2)
+        return self.bottleneck(h)            # (B, latent_dim)
+
+    def __call__(self, x, train: bool = False):
+        z = self.encode(x)                   # bottleneck code
+        return self.decoder(z)               # (B, 28, 28, in_ch) logits
+```
+
+The shapes flow like this:
+
+```
+x            (B, 28, 28, 1)
+ConvEncoder  (B,  7,  7, 32)   # two stride-2 convs, base=16 -> 32 channels
+flatten      (B, 1568)
+bottleneck   (B, 32)           # the compressed code z
+ConvDecoder  (B, 28, 28, 1)    # two ConvTranspose steps: 7 -> 14 -> 28 (logits)
+```
+
+Instantiate it with an explicit `nnx.Rngs` and pair it with an optimizer:
+
+```python
+model = ConvAutoencoder(latent_dim=32, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+## The training step
+
+The train step is the standard NNX pattern: a `loss_fn` closed over the model, `nnx.value_and_grad`, then `optimizer.update`. The batch carries a (possibly corrupted) input `x` and a **clean** `target`; for a plain autoencoder they are the same array.
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch['x'], train=True)      # (B, 28, 28, 1)
+        loss = bce_loss(logits, batch['target'])    # sigmoid-BCE per pixel
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, logits
+```
+
+## Denoising variant
+
+A **denoising autoencoder** keeps the exact same model and loss, but corrupts the *input* with Gaussian noise while asking the decoder to reproduce the *clean* image:
+
+$$
+\tilde{x} = \operatorname{clip}(x + \epsilon,\ 0,\ 1), \qquad
+\epsilon \sim \mathcal{N}(0, \sigma^2 I), \qquad
+\min_{\theta, \phi}\ \mathcal{L}\big(x,\ g_\phi(f_\theta(\tilde{x}))\big).
+$$
+
+Because the target is clean but the input is not, the network can no longer just memorize an identity map — it has to model how pixels relate so it can fill in what the noise destroyed.
+
+```python
+def add_gaussian_noise(x, key, std: float):
+    """Corrupt inputs with Gaussian noise, then clip back to [0, 1]."""
+    noisy = x + std * jax.random.normal(key, x.shape)
+    return jnp.clip(noisy, 0.0, 1.0)
+
+
+def make_batch(images, idx, *, denoising: bool, noise_std: float, key):
+    clean = images[idx]
+    x = add_gaussian_noise(clean, key, noise_std) if denoising else clean
+    return {'x': x, 'target': clean}          # input vs. clean target
+```
+
+Flip `denoising` on (the script reads a `DENOISE=1` env var) and everything else — model, loss, optimizer — stays identical.
+
+## Results / What to Expect
+
+The script defaults to tiny, offline **synthetic** binarized images (no downloads), so it runs on CPU in seconds. The BCE loss is summed over all 784 pixels, so it lives in the hundreds. Note the synthetic data is *pure random noise* with no structure to compress, so it sits near its entropy floor and the loss creeps down only slowly — the point of the synthetic default is that it runs offline and the loss *decreases*, not that it reaches zero. On real MNIST (`SYNTHETIC=0`) the digits are far more compressible and the loss falls much faster.
+
+```console
+$ python generative/autoencoder.py
+Convolutional autoencoder on synthetic data
+  epochs=4 batch=64 latent_dim=32 noise_std=0
+  dataset: (512, 28, 28, 1)  (clean targets in [0, 1])
+  epoch  1/4 | steps    8 | BCE   543.54
+  epoch  2/4 | steps   16 | BCE   543.21
+  epoch  3/4 | steps   24 | BCE   542.85
+  epoch  4/4 | steps   32 | BCE   542.26
+Done. The decoder's nnx.ConvTranspose layers upsample 7->14->28.
+```
+
+If you want to *watch* the loss drop sharply, run more steps on a single fixed batch (as the verification below does): on 30 steps of one batch it falls from ~544 to ~468.
+
+Run the denoising variant with `DENOISE=1 python generative/autoencoder.py`, or point it at MNIST with `SYNTHETIC=0`.
+
+## Common Pitfalls
+
+❌ **Applying a sigmoid inside the decoder, then also using sigmoid-BCE.**
+✅ Have the decoder return raw **logits** and let `bce_loss` (which wraps `optax.sigmoid_binary_cross_entropy`) apply the sigmoid once — double-sigmoid squashes gradients.
+
+❌ **Hardcoding the flatten size**, e.g. `h.reshape(B, 1568)`, which breaks if `base` or the input size changes.
+✅ Use `h.reshape(h.shape[0], -1)` so the bottleneck input dimension is derived from the tensor.
+
+❌ **Reconstructing the noisy input** in the denoising variant (`target = noisy`).
+✅ Corrupt only `batch['x']`; keep `batch['target']` the clean image, or the model just learns to copy noise.
+
+❌ **Making the bottleneck as wide as the input** (e.g. `latent_dim=784`).
+✅ Keep $d \ll 784$ (32 works well here) so the network is forced to compress instead of learning an identity map.
+
+❌ **Putting the encoder/decoder submodules in a plain Python `list`.**
+✅ On Flax 0.12 wrap any list of submodules in `nnx.List([...])` (the shared `ConvEncoder`/`ConvDecoder` already store their layers correctly).
+
+## Next steps
+
+- [Variational Autoencoders (VAE)](/applications/generative/vae) — put a probability distribution over the latent code and *sample* new digits.
+- [Generative Adversarial Networks (GAN)](/applications/generative/gan) — generate sharp images with an adversarial game instead of a reconstruction loss.
+
+## Complete Example
+
+[`examples/generative/autoencoder.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/autoencoder.py) — a runnable convolutional autoencoder with a denoising flag, synthetic-by-default data, and an MNIST switch.
+
+## References
+
+- Bengio, Courville & Vincent, [Representation Learning: A Review and New Perspectives](https://arxiv.org/abs/1206.5538) (2013) — autoencoders as representation learners.
+- Dumoulin & Visin, [A Guide to Convolution Arithmetic for Deep Learning](https://arxiv.org/abs/1603.07285) (2016) — how transposed convolutions upsample.
+- Kingma & Welling, [Auto-Encoding Variational Bayes](https://arxiv.org/abs/1312.6114) (2013) — the probabilistic extension covered in the VAE guide.

--- a/website/docs/applications/generative/diffusion.md
+++ b/website/docs/applications/generative/diffusion.md
@@ -1,0 +1,371 @@
+---
+sidebar_position: 4
+title: Diffusion Models (DDPM) in Flax NNX
+description: "Build a DDPM diffusion model in Flax NNX — a time-conditioned U-Net predicts noise, trained with an MSE objective and sampled by iterative denoising."
+keywords: [diffusion model, DDPM, Flax NNX, JAX, denoising, U-Net, generative model, DDIM, noise schedule, epsilon prediction]
+---
+
+# Diffusion Models (DDPM)
+
+Generate images by learning to *reverse* a gradual noising process: start from
+pure Gaussian noise and denoise it, one small step at a time, into a sample.
+
+:::note Prerequisites
+This is the capstone of the generative track. You should have built an
+[Autoencoder](/applications/generative/autoencoder) (the decoder/denoiser idea
+carries over) and be comfortable with convolutional blocks from the
+[ResNet architecture guide](/basics/vision/resnet-architecture). The training
+loop follows the patterns in [Custom Training Loops](/research/custom-training-loops).
+:::
+
+:::tip What you'll learn
+- The **forward process** that corrupts data with noise, and the closed form
+  $q(x_t\mid x_0)$ that lets you jump to any timestep in one shot
+- How to build a compact **time-conditioned U-Net** with `nnx.Embed` timestep
+  embeddings and `nnx.GroupNorm` conv blocks
+- The DDPM training objective — just an **MSE on predicted noise**
+- **Ancestral sampling**: the reverse denoising loop with `jax.lax.fori_loop`
+- Why diffusion is a **denoising autoencoder** in disguise, and how **DDIM**
+  makes sampling dramatically faster
+:::
+
+:::info Example Code
+See the full, runnable implementation:
+[`examples/generative/ddpm.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/ddpm.py)
+:::
+
+## The Motivation
+
+Autoencoders and VAEs compress data to a latent and decode it back in a single
+pass. Diffusion models take a different bet: instead of one hard generation
+step, **break generation into many easy denoising steps**. Each step only has to
+remove a little noise, which turns out to be a far more stable learning problem
+and produces state-of-the-art image quality.
+
+The recipe has two halves:
+
+1. **Forward process** (fixed, no learning): gradually add Gaussian noise to a
+   clean image until, after $T$ steps, it is indistinguishable from noise.
+2. **Reverse process** (learned): train a network to undo one step of noising.
+   Chain it $T$ times and you can walk pure noise back to a clean sample.
+
+## The Forward Process
+
+Define a small **variance schedule** $\beta_1,\dots,\beta_T$ (we use a linear
+ramp from $10^{-4}$ to $0.02$). One noising step is
+
+$$
+q(x_t \mid x_{t-1}) = \mathcal{N}\!\left(x_t;\, \sqrt{1-\beta_t}\,x_{t-1},\, \beta_t \mathbf{I}\right).
+$$
+
+The magic of Gaussians is that we never have to iterate this. With
+$\alpha_t = 1-\beta_t$ and the cumulative product
+$\bar\alpha_t = \prod_{s=1}^{t}\alpha_s$, we can sample **any** timestep directly
+from the clean image:
+
+$$
+q(x_t \mid x_0) = \mathcal{N}\!\left(x_t;\, \sqrt{\bar\alpha_t}\,x_0,\, (1-\bar\alpha_t)\mathbf{I}\right)
+\quad\Longleftrightarrow\quad
+x_t = \sqrt{\bar\alpha_t}\,x_0 + \sqrt{1-\bar\alpha_t}\,\epsilon,
+\;\; \epsilon\sim\mathcal{N}(0,\mathbf{I}).
+$$
+
+That one-line reparameterization is the whole forward process in code:
+
+```python
+import jax, jax.numpy as jnp
+from flax import nnx
+
+class DiffusionSchedule:
+    """Linear-beta schedule + closed-form forward process q(x_t | x_0).
+
+    A plain Python container of precomputed constants (NOT an nnx.Module),
+    so it never appears in the model's trainable state.
+    """
+    def __init__(self, T=200, beta_start=1e-4, beta_end=0.02):
+        self.T = T
+        betas = jnp.linspace(beta_start, beta_end, T)
+        self.betas = betas
+        self.alphas = 1.0 - betas
+        self.alphas_cumprod = jnp.cumprod(self.alphas)        # \bar{alpha}_t
+        self.sqrt_acp = jnp.sqrt(self.alphas_cumprod)
+        self.sqrt_one_minus_acp = jnp.sqrt(1.0 - self.alphas_cumprod)
+
+    def q_sample(self, x0, t, eps):
+        a = self.sqrt_acp[t][:, None, None, None]
+        b = self.sqrt_one_minus_acp[t][:, None, None, None]
+        return a * x0 + b * eps
+```
+
+## The Training Objective
+
+Ho et al. showed the variational bound simplifies to something startlingly
+plain: instead of predicting the denoised image, train the network
+$\epsilon_\theta$ to predict **the noise** that was added. The loss is a plain
+mean-squared error:
+
+$$
+L = \mathbb{E}_{t,\,x_0,\,\epsilon}\left\|\epsilon - \epsilon_\theta(x_t, t)\right\|^2 .
+$$
+
+Read literally: sample a clean image $x_0$, a random timestep $t$, and noise
+$\epsilon$; form $x_t$ with the closed form above; ask the network to guess
+$\epsilon$ from $x_t$ and $t$. Nothing more.
+
+### Connection to denoising autoencoders
+
+If you fix $t$ to a single noise level, this objective *is* a
+[denoising autoencoder](/applications/generative/autoencoder): corrupt the
+input, reconstruct the clean signal. Diffusion generalizes that to a **whole
+spectrum of noise levels** at once, sharing one network across all of them via
+the timestep conditioning. That shared, multi-scale denoiser is what makes the
+reverse chain possible.
+
+## The Model: a Time-Conditioned U-Net
+
+The network must know *how much* noise to remove, so every block receives the
+timestep embedding. We embed $t$ with `nnx.Embed` (a learned lookup table), pass
+it through a small MLP, and add it to the feature maps of each conv block.
+
+Each block is `Conv → GroupNorm → (+ time embedding) → SiLU`. We wrap the block's
+forward in `nnx.remat` (gradient checkpointing) to trade a little compute for
+lower memory — useful once you scale up.
+
+```python
+class ConvBlock(nnx.Module):
+    """Conv -> GroupNorm -> (+ time embedding) -> SiLU."""
+    def __init__(self, in_ch, out_ch, time_dim, *, stride=1, num_groups=8, rngs):
+        self.conv = nnx.Conv(in_ch, out_ch, kernel_size=(3, 3),
+                             strides=(stride, stride), padding='SAME', rngs=rngs)
+        self.norm = nnx.GroupNorm(out_ch, num_groups=num_groups, rngs=rngs)
+        self.time_proj = nnx.Linear(time_dim, out_ch, rngs=rngs)
+
+    @nnx.remat  # gradient checkpointing on the denoiser block
+    def __call__(self, x, t_emb):
+        h = self.conv(x)
+        h = self.norm(h)
+        h = h + self.time_proj(t_emb)[:, None, None, :]   # broadcast over H, W
+        return nnx.silu(h)
+```
+
+The U-Net itself is deliberately tiny — one downsample, one upsample, one skip
+connection (`~50k` params) so it trains in seconds on CPU. `nnx.ConvTranspose`
+does the learned upsampling, exactly as in the autoencoder decoder.
+
+```python
+class DDPMUNet(nnx.Module):
+    """Compact time-conditioned U-Net that predicts the noise eps."""
+    def __init__(self, T=200, base=16, time_dim=64, *, rngs):
+        # Learned timestep embedding: table lookup + small MLP.
+        self.time_embed = nnx.Embed(T, time_dim, rngs=rngs)
+        self.time_mlp1 = nnx.Linear(time_dim, time_dim, rngs=rngs)
+        self.time_mlp2 = nnx.Linear(time_dim, time_dim, rngs=rngs)
+
+        self.in_conv = nnx.Conv(1, base, kernel_size=(3, 3), padding='SAME', rngs=rngs)
+        self.down = ConvBlock(base, base * 2, time_dim, stride=2, rngs=rngs)   # 28 -> 14
+        self.mid = ConvBlock(base * 2, base * 2, time_dim, stride=1, rngs=rngs)
+        self.up = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                    strides=(2, 2), padding='SAME', rngs=rngs)  # 14 -> 28
+        self.out_block = ConvBlock(base * 2, base, time_dim, stride=1, rngs=rngs)
+        self.out_conv = nnx.Conv(base, 1, kernel_size=(3, 3), padding='SAME', rngs=rngs)
+
+    def __call__(self, x, t):
+        te = self.time_embed(t)                # (B, time_dim)
+        te = nnx.silu(self.time_mlp1(te))
+        te = self.time_mlp2(te)
+
+        h0 = nnx.silu(self.in_conv(x))         # (B,28,28,base)  -- skip source
+        h1 = self.down(h0, te)                 # (B,14,14,base*2)
+        h2 = self.mid(h1, te)                  # (B,14,14,base*2)
+        u = nnx.silu(self.up(h2))              # (B,28,28,base)
+        cat = jnp.concatenate([u, h0], axis=-1)  # skip connection
+        h = self.out_block(cat, te)            # (B,28,28,base)
+        return self.out_conv(h)                # (B,28,28,1) predicted noise
+```
+
+:::note GroupNorm over BatchNorm
+Diffusion networks use `nnx.GroupNorm`, not `nnx.BatchNorm`. Batch statistics
+are unreliable here — each example carries a *different, random* noise level, so
+per-group normalization is far more stable. Keep channel counts divisible by
+`num_groups` (here `8`).
+:::
+
+## The Training Step
+
+We keep the schedule out of the jitted step: a helper samples a random timestep
+and noise, forms $x_t$, and hands the step a ready-made batch. The step itself is
+the textbook NNX pattern — `nnx.value_and_grad` with `has_aux`, then
+`optimizer.update`.
+
+```python
+def sample_batch(schedule, x0, rng):
+    key_t, key_e = jax.random.split(rng)
+    t = jax.random.randint(key_t, (x0.shape[0],), 0, schedule.T)
+    eps = jax.random.normal(key_e, x0.shape)
+    x_t = schedule.q_sample(x0, t, eps)
+    return {'x_t': x_t, 't': t, 'eps': eps}
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        pred = model(batch['x_t'], batch['t'])
+        loss = jnp.mean((pred - batch['eps']) ** 2)   # MSE on the noise
+        return loss, pred
+    (loss, pred), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, pred
+```
+
+Build the model and optimizer with explicit RNGs and the modern `wrt=nnx.Param`
+optimizer API:
+
+```python
+schedule = DiffusionSchedule(T=200)
+model = DDPMUNet(T=200, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(2e-3), wrt=nnx.Param)
+```
+
+## Sampling: the Reverse Process
+
+Once $\epsilon_\theta$ is trained, generation runs the chain **backwards**.
+Starting from $x_T\sim\mathcal{N}(0,\mathbf{I})$, each step removes a bit of
+predicted noise:
+
+$$
+x_{t-1} = \frac{1}{\sqrt{\alpha_t}}\left(x_t - \frac{\beta_t}{\sqrt{1-\bar\alpha_t}}\,\epsilon_\theta(x_t, t)\right) + \sigma_t z,
+\qquad z\sim\mathcal{N}(0,\mathbf{I}),
+$$
+
+with $\sigma_t=\sqrt{\beta_t}$ and no noise added on the final step ($t=0$).
+
+We express the whole trajectory as one compiled `jax.lax.fori_loop`. Because the
+denoiser uses a lifted `nnx.remat` transform, we `nnx.split` the model and thread
+its (inference-only) state through the loop carry, re-merging inside the body —
+the idiomatic way to call an NNX module from a raw `lax` loop:
+
+```python
+def generate(model, schedule, num_samples, rng):
+    graphdef, state = nnx.split(model)
+    T = schedule.T
+    x = jax.random.normal(rng, (num_samples, 28, 28, 1))
+
+    def body(i, carry):
+        x, state, key = carry
+        m = nnx.merge(graphdef, state)               # rebuild at loop trace level
+        t = T - 1 - i                                # descend T-1 .. 0
+        key, subkey = jax.random.split(key)
+        t_batch = jnp.full((num_samples,), t, dtype=jnp.int32)
+
+        eps_theta = m(x, t_batch)
+        beta_t, alpha_t = schedule.betas[t], schedule.alphas[t]
+        acp_t = schedule.alphas_cumprod[t]
+
+        coef = beta_t / jnp.sqrt(1.0 - acp_t)
+        mean = (x - coef * eps_theta) / jnp.sqrt(alpha_t)
+
+        noise = jax.random.normal(subkey, x.shape)
+        add_noise = (t > 0).astype(x.dtype)          # no noise on the last step
+        x = mean + add_noise * jnp.sqrt(beta_t) * noise
+        return (x, state, key)
+
+    x, _, _ = jax.lax.fori_loop(0, T, body, (x, state, rng))
+    return x
+```
+
+## Faster Sampling with DDIM
+
+The DDPM sampler above needs *all* $T$ steps because it is a Markov chain.
+**DDIM** (Song et al., 2021) reinterprets the same trained $\epsilon_\theta$
+under a **non-Markovian**, deterministic process. First predict the clean image
+from the current noisy one,
+
+$$
+\hat{x}_0 = \frac{x_t - \sqrt{1-\bar\alpha_t}\,\epsilon_\theta(x_t,t)}{\sqrt{\bar\alpha_t}},
+$$
+
+then jump directly to an *arbitrary* earlier timestep $s < t$:
+
+$$
+x_s = \sqrt{\bar\alpha_s}\,\hat{x}_0 + \sqrt{1-\bar\alpha_s}\,\epsilon_\theta(x_t, t).
+$$
+
+Because you can skip timesteps, DDIM produces comparable samples in **20–50
+network evaluations instead of hundreds** — and, with the noise term dropped, it
+is fully deterministic, giving a reproducible map from latent noise to image. No
+retraining required: the same weights work for both samplers.
+
+## Results / What to Expect
+
+Running the verification harness (a 30-step CPU smoke test on synthetic
+Gaussian-blob images) the noise-prediction MSE falls steadily as the denoiser
+learns:
+
+```text
+params: 49,921
+forward out shape: (8, 28, 28, 1)
+loss[0]=1.4977  loss[-1]=0.1156
+loss trace (every 5): [1.4977, 0.4235, 0.2436, 0.22, 0.164, 0.1269]
+generated shape: (4, 28, 28, 1)
+
+ALL ASSERTS PASSED
+```
+
+A random-noise baseline scores a loss of $\approx 1.0$ (predicting zeros).
+Dropping well below that means the network is genuinely recovering the injected
+noise. The full script (`python generative/ddpm.py`) trains a few epochs and
+then draws four samples from pure noise:
+
+```text
+  epoch  1/3 | noise-MSE: 0.7321
+  epoch  2/3 | noise-MSE: 0.2676
+  epoch  3/3 | noise-MSE: 0.1856
+
+  generated samples: (4, 28, 28, 1) range=[-2.13, 2.78]
+```
+
+On real MNIST (`SYNTHETIC=0`) with more epochs the samples sharpen into
+recognizable digits; on CPU, keep `T` and the dataset small.
+
+## Common Pitfalls
+
+**Predicting the image instead of the noise**
+❌ Regressing $x_0$ directly is harder to optimize and trains slowly.
+✅ Predict $\epsilon$ (the $\epsilon$-parameterization) and use the plain MSE loss.
+
+**Wrong noise-injection formula**
+❌ `x_t = x0 + t * eps` or forgetting the `sqrt`.
+✅ `x_t = sqrt(acp)*x0 + sqrt(1-acp)*eps` with `acp = alphas_cumprod[t]`.
+
+**BatchNorm inside the denoiser**
+❌ `nnx.BatchNorm` mixes examples that sit at wildly different noise levels.
+✅ Use `nnx.GroupNorm` (channels divisible by `num_groups`).
+
+**Forgetting the timestep conditioning**
+❌ A network that ignores $t$ cannot know how much noise to remove.
+✅ Embed $t$ with `nnx.Embed` and add its projection into every block.
+
+**Adding noise on the final reverse step**
+❌ Injecting $\sigma_t z$ at $t=0$ leaves visible speckle on the output.
+✅ Gate the noise term with `(t > 0)` so the last step is deterministic.
+
+## Next steps
+
+- [Variational Autoencoders (VAE)](/applications/generative/vae) — the other
+  principled latent-variable generator; contrast its single-step ELBO with
+  diffusion's many-step objective.
+- [Generative Adversarial Networks (GAN)](/applications/generative/gan) — learn
+  the data density *implicitly* through an adversarial game.
+
+## Complete Example
+
+- [`examples/generative/ddpm.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/ddpm.py)
+  — a complete, CPU-verifiable DDPM: linear noise schedule, time-conditioned
+  U-Net denoiser, MSE training step, and `fori_loop` ancestral sampling.
+
+## References
+
+- **DDPM**: [Denoising Diffusion Probabilistic Models](https://arxiv.org/abs/2006.11239) (Ho, Jain & Abbeel, 2020)
+- **DDIM**: [Denoising Diffusion Implicit Models](https://arxiv.org/abs/2010.02502) (Song, Meng & Ermon, 2021)
+- **Score-based view**: [Score-Based Generative Modeling through SDEs](https://arxiv.org/abs/2011.13456) (Song et al., 2021)
+- **Improved DDPM**: [Improved Denoising Diffusion Probabilistic Models](https://arxiv.org/abs/2102.09672) (Nichol & Dhariwal, 2021)
+- **Original diffusion**: [Deep Unsupervised Learning using Nonequilibrium Thermodynamics](https://arxiv.org/abs/1503.03585) (Sohl-Dickstein et al., 2015)

--- a/website/docs/applications/generative/gan.md
+++ b/website/docs/applications/generative/gan.md
@@ -1,0 +1,294 @@
+---
+sidebar_position: 3
+title: DCGAN in Flax NNX - Adversarial Image Generation
+description: "Build a DCGAN on MNIST with Flax NNX: the minimax game, the non-saturating generator loss, two optimizers, and SpectralNorm to tame mode collapse."
+keywords: [GAN, DCGAN, generative adversarial network, flax nnx, jax, spectral normalization, non-saturating loss, mode collapse, minimax, image generation]
+---
+
+# Deep Convolutional GAN (DCGAN)
+
+Pit a forger against a detective: two networks train against each other until the fakes become indistinguishable from real digits.
+
+:::note Prerequisites
+- [Variational Autoencoder (VAE)](/applications/generative/vae) — the `nnx.ConvTranspose` decoder and MNIST scaling this guide builds on.
+- [Custom Training Loops](/research/custom-training-loops) — GANs need two optimizers and hand-written alternating updates.
+:::
+
+:::tip What you'll learn
+- The **minimax game** behind GANs and how a generator and discriminator co-evolve.
+- The **non-saturating** generator loss, and why the naive minimax objective stalls early.
+- Driving **two independent `nnx.Optimizer`s** — one per network — with separate `@nnx.jit` steps.
+- Applying **`nnx.SpectralNorm`** to the discriminator to bound its Lipschitz constant and stabilize training.
+- What **mode collapse** looks like and how to recognize healthy adversarial losses.
+:::
+
+:::info Example Code
+The complete, runnable script for this guide lives at
+[`examples/generative/dcgan.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/dcgan.py).
+:::
+
+## The adversarial idea
+
+A [VAE](/applications/generative/vae) learns an *explicit* density by maximizing a
+likelihood bound. A **generative adversarial network** takes the opposite route:
+it learns the data distribution *implicitly* by playing a game.
+
+Two networks compete:
+
+- The **generator** $G$ maps a random latent vector $z \sim \mathcal{N}(0, I)$ to
+  a fake image $G(z)$. It never sees real data directly — it only learns from the
+  discriminator's feedback.
+- The **discriminator** $D$ takes an image and outputs a single logit: high for
+  real, low for fake.
+
+$D$ is trained to tell real from fake; $G$ is trained to fool $D$. As $D$ gets
+sharper, $G$ is pushed to produce ever more realistic samples, until — at the
+theoretical optimum — the fakes match the real distribution and $D$ can only
+guess.
+
+## The math: a minimax game
+
+Goodfellow et al. framed this as a two-player minimax game with value function
+
+$$
+\min_G \max_D \; \mathbb{E}_{x \sim p_{\text{data}}}\big[\log D(x)\big]
+\;+\; \mathbb{E}_{z \sim p_z}\big[\log\big(1 - D(G(z))\big)\big]
+$$
+
+The discriminator maximizes this: it wants $D(x) \to 1$ on real data and
+$D(G(z)) \to 0$ on fakes. The generator minimizes the second term: it wants
+$D(G(z)) \to 1$.
+
+### The non-saturating trick
+
+In practice, minimizing $\log(1 - D(G(z)))$ directly is a bad idea. Early in
+training the discriminator easily rejects the generator's garbage, so
+$D(G(z)) \approx 0$ — exactly where $\log(1 - D(G(z)))$ is **flat**, giving the
+generator almost no gradient. The generator starves precisely when it needs to
+learn the most.
+
+The fix is the **non-saturating** loss: instead of minimizing
+$\log(1 - D(G(z)))$, the generator *maximizes* $\log D(G(z))$ — equivalently, it
+minimizes the binary cross-entropy of the fake logits against the label **1**:
+
+$$
+\mathcal{L}_G = -\,\mathbb{E}_{z}\big[\log D(G(z))\big], \qquad
+\mathcal{L}_D = -\,\mathbb{E}_{x}\big[\log D(x)\big] - \mathbb{E}_{z}\big[\log\big(1 - D(G(z))\big)\big]
+$$
+
+Both are just sigmoid **binary cross-entropy** with the right target labels —
+$1$ for "should look real", $0$ for "should look fake" — which is numerically
+stable when computed from logits.
+
+## Building the generator
+
+The generator mirrors a VAE decoder: project the latent vector into a small
+spatial grid, then upsample with strided `nnx.ConvTranspose` layers. The final
+`nnx.tanh` puts pixels in $[-1, 1]$, so **real images are scaled to $[-1, 1]$ too**.
+
+```python
+from flax import nnx
+
+class Generator(nnx.Module):
+    def __init__(self, z_dim: int = 64, base: int = 16, *, rngs: nnx.Rngs):
+        self.z_dim = z_dim
+        self.base = base
+        self.fc = nnx.Linear(z_dim, base * 2 * 7 * 7, rngs=rngs)
+        self.deconv1 = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                         strides=(2, 2), padding='SAME', rngs=rngs)  # 7 -> 14
+        self.deconv2 = nnx.ConvTranspose(base, 1, kernel_size=(3, 3),
+                                         strides=(2, 2), padding='SAME', rngs=rngs)  # 14 -> 28
+
+    def __call__(self, z):
+        h = self.fc(z)
+        h = h.reshape(z.shape[0], 7, 7, self.base * 2)
+        h = nnx.relu(self.deconv1(h))
+        h = self.deconv2(h)
+        return nnx.tanh(h)   # outputs in [-1, 1]
+```
+
+## Building the discriminator (with SpectralNorm)
+
+The discriminator is a plain strided-conv classifier, but every conv/linear
+kernel is wrapped in **`nnx.SpectralNorm`**. Spectral normalization divides each
+weight matrix by its largest singular value (estimated with power iteration),
+which bounds the network's Lipschitz constant. That keeps the discriminator from
+becoming arbitrarily confident — a runaway $D$ produces exploding gradients and
+collapses the game — so the two players stay in balance.
+
+```python
+class Discriminator(nnx.Module):
+    def __init__(self, base: int = 16, *, rngs: nnx.Rngs):
+        self.conv1 = nnx.SpectralNorm(
+            nnx.Conv(1, base, kernel_size=(3, 3), strides=(2, 2),
+                     padding='SAME', rngs=rngs), rngs=rngs)          # 28 -> 14
+        self.conv2 = nnx.SpectralNorm(
+            nnx.Conv(base, base * 2, kernel_size=(3, 3), strides=(2, 2),
+                     padding='SAME', rngs=rngs), rngs=rngs)          # 14 -> 7
+        self.fc = nnx.SpectralNorm(
+            nnx.Linear(base * 2 * 7 * 7, 1, rngs=rngs), rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        # update_stats only when we are actually training the discriminator.
+        x = nnx.leaky_relu(self.conv1(x, update_stats=train), negative_slope=0.2)
+        x = nnx.leaky_relu(self.conv2(x, update_stats=train), negative_slope=0.2)
+        x = x.reshape(x.shape[0], -1)
+        return self.fc(x, update_stats=train)   # (B, 1) logit
+```
+
+`nnx.SpectralNorm` keeps its power-iteration estimate (`u`, `sigma`) as
+`BatchStat` variables, not `Param`s — so they are *not* differentiated by
+`wrt=nnx.Param`, and we only refresh them (`update_stats=True`) while the
+discriminator is the one being optimized.
+
+## Two optimizers
+
+A GAN has two sets of parameters updated by two different objectives, so it needs
+**two optimizers**. We use Adam with a low learning rate and $\beta_1 = 0.5$ — the
+DCGAN recipe that damps the momentum term Adam would otherwise carry across the
+adversarial oscillation.
+
+```python
+import optax
+
+rngs = nnx.Rngs(0)
+gen = Generator(z_dim=64, rngs=rngs)
+disc = Discriminator(rngs=rngs)
+
+opt_g = nnx.Optimizer(gen, optax.adam(2e-4, b1=0.5), wrt=nnx.Param)
+opt_d = nnx.Optimizer(disc, optax.adam(2e-4, b1=0.5), wrt=nnx.Param)
+```
+
+## The two training steps
+
+Each network gets its own `@nnx.jit` step. The discriminator step pushes real
+logits up and fake logits down; the generator step uses the non-saturating loss,
+labeling its own fakes as **real**.
+
+The shared `bce_loss(logits, targets)` is exactly sigmoid binary cross-entropy
+computed from logits, so we feed it target tensors of ones or zeros.
+
+```python
+from shared.training_utils import bce_loss
+
+@nnx.jit
+def d_step(gen, disc, opt_d, real, z):
+    fake = gen(z)   # generator is fixed here (not in the grad set)
+
+    def loss_fn(disc):
+        real_logits = disc(real, train=True)
+        fake_logits = disc(fake, train=True)
+        loss = (bce_loss(real_logits, jnp.ones_like(real_logits))
+                + bce_loss(fake_logits, jnp.zeros_like(fake_logits)))
+        return loss, (real_logits, fake_logits)
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(disc)
+    opt_d.update(disc, grads)
+    return loss, aux
+
+
+@nnx.jit
+def g_step(gen, disc, opt_g, z):
+    def loss_fn(gen, disc):
+        fake = gen(z)
+        fake_logits = disc(fake, train=False)   # discriminator frozen
+        loss = bce_loss(fake_logits, jnp.ones_like(fake_logits))
+        return loss, fake_logits
+
+    # Pass disc as a (non-differentiated) argument so its spectral-norm layers
+    # stay at the transform's trace level; value_and_grad differentiates
+    # argnums=0 (gen) only.
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(gen, disc)
+    opt_g.update(gen, grads)
+    return loss, aux
+```
+
+Two subtleties worth calling out:
+
+- In `d_step`, the fake batch is computed *outside* `loss_fn`, so the generator
+  is treated as a constant — no gradients leak into $G$ while training $D$.
+- In `g_step`, we differentiate w.r.t. `gen` only, but we still pass `disc` **into**
+  `value_and_grad`. `nnx.SpectralNorm` mutates its layer's weights in place on
+  every call; passing `disc` as a transform argument keeps that mutation at the
+  correct JAX trace level and avoids a `TraceContextError`.
+
+The training loop just alternates them, one discriminator update then one
+generator update per batch:
+
+```python
+d_loss, _ = d_step(gen, disc, opt_d, real, sample_z(kd, batch, z_dim))
+g_loss, _ = g_step(gen, disc, opt_g, sample_z(kg, batch, z_dim))
+```
+
+## Results / What to Expect
+
+Running the script on CPU with the synthetic defaults produces output like:
+
+```console
+$ python generative/dcgan.py
+epoch 0: d_loss=1.2278  g_loss=0.6531
+epoch 1: d_loss=1.0854  g_loss=0.6295
+```
+
+Do **not** expect the losses to fall monotonically — that is the wrong mental
+model for a GAN. Because $G$ and $D$ optimize *opposing* objectives, the losses
+oscillate: when the generator improves, the discriminator's job gets harder (its
+loss rises), and vice versa. A healthy run keeps both losses **finite and bounded**
+and hovering in a stable range, with $d\_loss$ roughly around $2\log 2 \approx
+1.39$ and $g\_loss$ near $\log 2 \approx 0.69$ at the theoretical equilibrium
+where $D(x) = D(G(z)) = 0.5$.
+
+What you *should* watch for instead: `NaN`/`inf` losses (the discriminator
+overpowered the generator — spectral norm is your first defense), or a
+$g\_loss$ that climbs to the sky while $d\_loss$ crashes to zero (the
+discriminator won outright and the generator's gradient vanished).
+
+Set `SYNTHETIC=0` to train on real MNIST via `tfds`, and tune `EPOCHS` / `BATCH`
+through environment variables.
+
+## Common Pitfalls
+
+- ❌ Using the naive minimax generator loss, minimizing `log(1 - D(G(z)))`.
+  ✅ Use the **non-saturating** loss — BCE of the fake logits against label `1` —
+  so the generator gets strong gradients even while its samples are poor.
+
+- ❌ Feeding raw $[0, 1]$ images to a discriminator whose generator ends in `tanh`.
+  ✅ Scale real images to $[-1, 1]$ (e.g. `img * 2 - 1`) so real and fake share the
+  same range.
+
+- ❌ Sharing one optimizer, or letting the generator step leak gradients into the
+  discriminator.
+  ✅ Keep **two** `nnx.Optimizer`s; compute the fake batch outside `loss_fn` in
+  `d_step`, and differentiate `g_step` w.r.t. the generator only.
+
+- ❌ Applying `sigmoid` inside the discriminator and then using BCE (double sigmoid,
+  unstable).
+  ✅ Return raw **logits** from the discriminator and use sigmoid-BCE from logits.
+
+- ❌ An unconstrained discriminator that grows arbitrarily confident, exploding the
+  generator's gradients (classic **mode collapse**, where $G$ emits one repeated
+  sample).
+  ✅ Wrap the discriminator's conv/linear kernels in `nnx.SpectralNorm` to bound its
+  Lipschitz constant and keep the game balanced.
+
+## Next steps
+
+- [Diffusion Models (DDPM)](/applications/generative/diffusion) — swap the
+  adversarial game for iterative denoising, trading training instability for many
+  sampling steps.
+- [Variational Autoencoder (VAE)](/applications/generative/vae) — the explicit,
+  likelihood-based alternative to the implicit GAN objective.
+
+## Complete Example
+
+The full, verified script is at
+[`examples/generative/dcgan.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/dcgan.py)
+— a CPU-friendly DCGAN with synthetic-data defaults, spectral-normalized
+discriminator, two optimizers, and alternating `@nnx.jit` train steps.
+
+## References
+
+- Goodfellow et al., *Generative Adversarial Networks* (2014). [arXiv:1406.2661](https://arxiv.org/abs/1406.2661)
+- Radford, Metz & Chintala, *Unsupervised Representation Learning with Deep Convolutional GANs (DCGAN)* (2015). [arXiv:1511.06434](https://arxiv.org/abs/1511.06434)
+- Miyato et al., *Spectral Normalization for Generative Adversarial Networks* (2018). [arXiv:1802.05957](https://arxiv.org/abs/1802.05957)
+- Arjovsky, Chintala & Bottou, *Wasserstein GAN* (2017). [arXiv:1701.07875](https://arxiv.org/abs/1701.07875)

--- a/website/docs/applications/generative/index.md
+++ b/website/docs/applications/generative/index.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 0
+title: Generative Models in Flax NNX
+description: Build autoencoders, VAEs, GANs, and diffusion models from scratch in Flax NNX — learn to generate images with nnx.ConvTranspose and custom losses.
+keywords: [generative models, autoencoder, VAE, GAN, diffusion, DDPM, flax nnx, jax, ConvTranspose]
+---
+
+# Generative Models
+
+Generative models learn the *distribution* of data so they can produce new
+samples — new digits, new images — rather than just labeling existing ones. This
+track builds four families from scratch, each adding one new idea about how to
+model that distribution.
+
+## What you'll build
+
+- **[Autoencoders](/applications/generative/autoencoder)** — compress and
+  reconstruct images through a bottleneck. Introduces `nnx.ConvTranspose` for
+  learned upsampling (the decoder primitive every later guide reuses).
+- **[Variational Autoencoders (VAE)](/applications/generative/vae)** — put a
+  *probability distribution* over the latent space and sample new digits, using
+  the reparameterization trick and the ELBO objective.
+- **[Generative Adversarial Networks (GAN)](/applications/generative/gan)** — a
+  generator and discriminator locked in a game; learn density *implicitly* with
+  two optimizers and spectral normalization.
+- **[Diffusion Models (DDPM)](/applications/generative/diffusion)** — generate by
+  iteratively denoising pure noise; a small U-Net predicts the noise at each step.
+
+## Suggested order
+
+Read top to bottom: each guide builds on the previous one's intuition
+(reconstruction → latent distribution → adversarial → iterative denoising).
+
+## Prerequisites
+
+You should be comfortable with [CNNs](/basics/vision/simple-cnn) and the
+[training loop](/basics/workflows/simple-training). VAE and beyond lean on
+[Flax NNX state and RNGs](/basics/fundamentals/understanding-state).
+
+## Next steps
+
+- Start with the [Autoencoder](/applications/generative/autoencoder).
+- Compare with self-supervised [Contrastive Learning](/research/contrastive-learning).

--- a/website/docs/applications/generative/index.md
+++ b/website/docs/applications/generative/index.md
@@ -25,6 +25,9 @@ model that distribution.
   two optimizers and spectral normalization.
 - **[Diffusion Models (DDPM)](/applications/generative/diffusion)** — generate by
   iteratively denoising pure noise; a small U-Net predicts the noise at each step.
+- **[Normalizing Flows](/applications/generative/normalizing-flows)** — an
+  *invertible* network that gives you the exact likelihood via the change-of-variables
+  formula (RealNVP coupling layers).
 
 ## Suggested order
 

--- a/website/docs/applications/generative/normalizing-flows.md
+++ b/website/docs/applications/generative/normalizing-flows.md
@@ -1,0 +1,303 @@
+---
+sidebar_position: 5
+title: Normalizing Flows (RealNVP) in Flax NNX
+description: "Build a RealNVP normalizing flow on two-moons with Flax NNX: affine coupling layers, exact log-likelihood via change of variables, and invertible sampling."
+keywords: [normalizing flows, RealNVP, affine coupling, flax nnx, jax, change of variables, exact likelihood, invertible neural network, generative model, log-determinant]
+---
+
+# Normalizing Flows (RealNVP)
+
+Learn an *exact*, invertible density: turn two crescent moons into a Gaussian, then run the map backwards to sample brand-new points.
+
+:::note Prerequisites
+- [Variational Autoencoder (VAE)](/applications/generative/vae) — the encoder/decoder generative baseline this guide contrasts with.
+- [Simple Training Loop](/basics/workflows/simple-training) — the `nnx.value_and_grad` + `optimizer.update` pattern reused here.
+:::
+
+:::tip What you'll learn
+- The **change-of-variables** formula and why an invertible network gives you *exact* log-likelihood (no ELBO, no adversary).
+- How an **affine coupling layer** stays invertible while its Jacobian log-determinant collapses to a simple `sum(s)`.
+- Why stacking layers with **alternating masks** lets every dimension get transformed.
+- Training a flow by **maximum likelihood** — minimizing the mean negative log-density directly.
+- Using one network for two directions: `forward` (data → base) to score, `inverse` (base → data) to sample.
+:::
+
+:::info Example Code
+The complete, runnable script for this guide lives at
+[`examples/generative/normalizing_flows.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/normalizing_flows.py).
+:::
+
+## Why an invertible model?
+
+A [VAE](/applications/generative/vae) only ever gives you a *lower bound* on the
+likelihood, and a [GAN](/applications/generative/gan) gives you no likelihood at
+all. A **normalizing flow** takes a different bargain: build the generator out of
+*invertible* transformations so you can compute the data density **exactly**.
+
+The idea is to warp a simple base distribution — here a standard normal
+$p_Z = \mathcal{N}(0, I)$ — into the complicated data distribution through a
+learnable bijection $f$. If $z = f(x)$ is invertible and differentiable, the
+**change-of-variables** formula gives the density of $x$ exactly:
+
+$$
+\log p_X(x) = \log p_Z\big(f(x)\big) + \log\left|\det \frac{\partial f(x)}{\partial x}\right|
+$$
+
+Two directions fall out of one model:
+
+- **Score / train** — push data through the forward map $x \to z$, evaluate the
+  base density and the log-determinant, and maximize $\log p_X(x)$.
+- **Sample** — draw $z \sim \mathcal{N}(0, I)$ and run the map *backwards*,
+  $x = f^{-1}(z)$.
+
+The catch is the $\log|\det|$ term: for a general network the Jacobian
+determinant costs $O(d^3)$. **RealNVP** solves this with a layer whose Jacobian
+is triangular, so the determinant is just the product of its diagonal.
+
+## Affine coupling layers
+
+RealNVP splits the input into two halves. One half passes through untouched and
+*conditions* an affine transform (scale and shift) applied to the other half. We
+select the halves with a binary mask $m \in \{0, 1\}^d$:
+
+$$
+\begin{aligned}
+z &= m \odot x \;+\; (1 - m) \odot \big(x \odot e^{s(m \odot x)} + t(m \odot x)\big) \\
+\log\left|\det \frac{\partial z}{\partial x}\right| &= \sum_j (1 - m_j)\, s_j
+\end{aligned}
+$$
+
+Because the kept half is copied verbatim and the transformed half depends on it
+only through $s$ and $t$, the Jacobian is triangular — its log-determinant is
+simply the sum of the scales $s$. The network predicting $s$ and $t$ can be
+*arbitrarily* complex; invertibility never depends on it.
+
+Inverting is closed-form. Given $z$, the kept half already equals $x$'s kept
+half, so we recompute the *same* $s$ and $t$ and undo the affine map:
+
+$$
+x = m \odot z \;+\; (1 - m) \odot (z - t) \odot e^{-s}
+$$
+
+A single layer leaves half the dimensions unchanged, so we **stack** layers and
+**alternate** the mask parity. After two layers every dimension has been both a
+conditioner and a transform target.
+
+```python
+from flax import nnx
+import jax.numpy as jnp
+from shared.models import MLP
+
+class AffineCoupling(nnx.Module):
+    def __init__(self, dim: int, hidden: int, parity: int, *, rngs: nnx.Rngs):
+        self.dim = dim
+        self.parity = parity
+        # Conditioner: (kept dims) -> concat[s_raw, t], each of size `dim`.
+        self.net = MLP(dim, hidden, 2 * dim, n_layers=2, rngs=rngs, activation="gelu")
+
+    def _mask(self):
+        # 1.0 where a dim is kept (conditions), 0.0 where it is transformed.
+        return (jnp.arange(self.dim) % 2 == self.parity).astype(jnp.float32)
+
+    def _s_t(self, u, mask):
+        s_raw, t = jnp.split(self.net(u * mask), 2, axis=-1)
+        s = jnp.tanh(s_raw) * (1.0 - mask)   # bounded scale, transformed dims only
+        t = t * (1.0 - mask)                 # shift, transformed dims only
+        return s, t
+
+    def forward(self, x):
+        mask = self._mask()
+        s, t = self._s_t(x, mask)
+        z = x * mask + (1.0 - mask) * (x * jnp.exp(s) + t)
+        logdet = jnp.sum(s, axis=-1)
+        return z, logdet
+
+    def inverse(self, z):
+        mask = self._mask()
+        s, t = self._s_t(z, mask)  # kept dims == x's kept dims, so s,t match
+        x = z * mask + (1.0 - mask) * (z - t) * jnp.exp(-s)
+        return x
+```
+
+We squash the raw scale with `tanh` so $e^{s}$ stays in a stable range — a common
+RealNVP trick that keeps early training from exploding.
+
+## Stacking into a flow
+
+The `RealNVP` module composes the coupling layers. `forward` accumulates the
+total log-determinant; `inverse` replays the layers in reverse. `log_prob` glues
+them to the standard-normal base, and `sample` runs the flow backwards from base
+noise.
+
+```python
+import jax
+import jax.numpy as jnp
+
+class RealNVP(nnx.Module):
+    def __init__(self, dim=2, hidden=64, n_layers=6, *, rngs: nnx.Rngs):
+        self.dim = dim
+        # A plain list of submodules MUST be wrapped in nnx.List on Flax 0.12.
+        self.layers = nnx.List([
+            AffineCoupling(dim, hidden, parity=i % 2, rngs=rngs)
+            for i in range(n_layers)
+        ])
+
+    def forward(self, x):
+        logdet = jnp.zeros(x.shape[0])
+        z = x
+        for layer in self.layers:
+            z, ld = layer.forward(z)
+            logdet = logdet + ld
+        return z, logdet
+
+    def inverse(self, z):
+        x = z
+        for i in range(len(self.layers) - 1, -1, -1):
+            x = self.layers[i].inverse(x)
+        return x
+
+    def log_prob(self, x):
+        z, logdet = self.forward(x)
+        # log N(z; 0, I) = -0.5||z||^2 - 0.5 d log(2*pi)
+        logpz = -0.5 * jnp.sum(z ** 2, axis=-1) - 0.5 * self.dim * jnp.log(2.0 * jnp.pi)
+        return logpz + logdet
+
+    def sample(self, n: int, seed: int = 0):
+        z = jax.random.normal(jax.random.key(seed), (n, self.dim))
+        return self.inverse(z)
+```
+
+:::caution nnx.List is required
+A raw Python `list` of submodules is invisible to Flax 0.12's pytree machinery —
+their parameters won't register and training crashes. Always wrap submodule lists
+in `nnx.List([...])` (and dicts in `nnx.Dict({...})`).
+:::
+
+## The loss and train step
+
+Training a flow is refreshingly direct: **minimize the mean negative
+log-likelihood**. There's no lower bound and no discriminator — the model reports
+its own exact density.
+
+```python
+def nll_loss(model, x):
+    return -model.log_prob(x).mean()
+```
+
+The train step is the standard NNX pattern — `nnx.value_and_grad` with
+`has_aux=True`, then `optimizer.update(model, grads)`:
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        nll = nll_loss(model, batch)
+        return nll, nll   # aux = nll for logging
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, aux
+```
+
+Wire it up with a single RNG stream and Adam:
+
+```python
+import optax
+
+rngs = nnx.Rngs(0)
+model = RealNVP(dim=2, hidden=64, n_layers=6, rngs=rngs)
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+## The data: two moons, no sklearn
+
+We generate the classic two-moons set ourselves from two noisy half circles and
+standardize it so the $\mathcal{N}(0, I)$ base is a good target — fully offline,
+no downloads.
+
+```python
+def make_two_moons(n=1024, noise=0.1, seed=0):
+    key = jax.random.key(seed)
+    k1, k2, k3 = jax.random.split(key, 3)
+    n_out, n_in = n // 2, n - n // 2
+
+    t_out = jnp.pi * jax.random.uniform(k1, (n_out,))
+    outer = jnp.stack([jnp.cos(t_out), jnp.sin(t_out)], axis=1)
+
+    t_in = jnp.pi * jax.random.uniform(k2, (n_in,))
+    inner = jnp.stack([1.0 - jnp.cos(t_in), 1.0 - jnp.sin(t_in) - 0.5], axis=1)
+
+    x = jnp.concatenate([outer, inner], axis=0)
+    x = x + noise * jax.random.normal(k3, x.shape)
+    return (x - x.mean(0)) / (x.std(0) + 1e-6)   # standardize per dim
+```
+
+## Results / What to expect
+
+The script defaults to tiny synthetic data so it runs offline on CPU in seconds.
+The mean negative log-likelihood falls steadily as the flow warps the moons onto
+the Gaussian:
+
+```console
+$ python generative/normalizing_flows.py
+epoch 1/8  nll 2.9005
+epoch 2/8  nll 2.6915
+epoch 3/8  nll 2.6044
+epoch 4/8  nll 2.5378
+epoch 5/8  nll 2.4859
+epoch 6/8  nll 2.4423
+epoch 7/8  nll 2.4069
+epoch 8/8  nll 2.3750
+samples: (256, 2)  latent: (256, 2)
+```
+
+Two invariants make this model trustworthy, and the example verifies both:
+
+- **Exact invertibility** — `inverse(forward(x))` reconstructs `x` to
+  `~1e-6` (float32 round-off), confirming the affine coupling is a true bijection.
+- **Faithful sampling** — `model.sample(n, seed)` returns `(n, 2)` points that,
+  once training converges, trace out the two crescents. Because the flow is exact,
+  those samples come straight from `z ~ N(0, I)` pushed through `inverse`.
+
+Tune `EPOCHS`, `BATCH`, and `SYNTHETIC` (dataset size) via environment variables
+to trade runtime for a sharper fit.
+
+## Common Pitfalls
+
+- ❌ Storing submodules in a plain Python `list`, so their params never register.
+  ✅ Wrap them in `nnx.List([...])` (and dicts in `nnx.Dict({...})`) on Flax 0.12.
+
+- ❌ Letting the scale $s$ run unbounded — `exp(s)` overflows to `inf`/`NaN` early.
+  ✅ Squash it: `s = jnp.tanh(s_raw)`, keeping $e^{s}$ in a stable band.
+
+- ❌ Forgetting the $\log|\det|$ term and training on `-log p_z(f(x))` alone.
+  ✅ Return `logpz + logdet` from `log_prob`; without the Jacobian term the model
+  cheaply collapses all mass to one point.
+
+- ❌ Running the same layer order for `inverse` as `forward`.
+  ✅ Apply layers in **reverse** during `inverse` — a flow is $f_L \circ \dots \circ f_1$,
+  so its inverse is $f_1^{-1} \circ \dots \circ f_L^{-1}$.
+
+- ❌ Feeding raw, unscaled two-moons into a $\mathcal{N}(0, I)$ base.
+  ✅ Standardize the data (zero mean, unit variance) so the base is a reachable target.
+
+## Next steps
+
+- [Diffusion Models (DDPM)](/applications/generative/diffusion) — another exact-ish
+  likelihood generator that trades one invertible map for many denoising steps.
+- [Generative Adversarial Networks (GAN)](/applications/generative/gan) — the
+  likelihood-free alternative that learns the density *implicitly*.
+
+## Complete Example
+
+The full, verified script is at
+[`examples/generative/normalizing_flows.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/normalizing_flows.py)
+— a CPU-friendly RealNVP with synthetic two-moons defaults, exact-likelihood
+training loop, invertibility check, and a `sample()` generator.
+
+## References
+
+- Dinh, Sohl-Dickstein & Bengio, *Density Estimation using Real NVP* (2016). [arXiv:1605.08803](https://arxiv.org/abs/1605.08803)
+- Dinh, Krueger & Bengio, *NICE: Non-linear Independent Components Estimation* (2014). [arXiv:1410.8516](https://arxiv.org/abs/1410.8516)
+- Rezende & Mohamed, *Variational Inference with Normalizing Flows* (2015). [arXiv:1505.05770](https://arxiv.org/abs/1505.05770)
+- Papamakarios et al., *Normalizing Flows for Probabilistic Modeling and Inference* (2019). [arXiv:1912.02762](https://arxiv.org/abs/1912.02762)

--- a/website/docs/applications/generative/vae.md
+++ b/website/docs/applications/generative/vae.md
@@ -1,0 +1,263 @@
+---
+sidebar_position: 2
+title: Variational Autoencoder (VAE) in Flax NNX
+description: "Build a VAE on MNIST with Flax NNX: the reparameterization trick, the ELBO objective, and separate params/noise RNG streams for sampling a latent space."
+keywords: [variational autoencoder, VAE, flax nnx, jax, reparameterization trick, ELBO, KL divergence, latent variable model, generative model]
+---
+
+# Variational Autoencoder (VAE)
+
+Turn an autoencoder's bottleneck into a *probability distribution* you can sample from, and generate brand-new digits.
+
+:::note Prerequisites
+- [Autoencoders](/applications/generative/autoencoder) — the encoder/decoder and `nnx.ConvTranspose` upsampling this guide reuses.
+- [Understanding State & RNGs](/basics/fundamentals/understanding-state) — why NNX makes randomness explicit.
+:::
+
+:::tip What you'll learn
+- Why a plain autoencoder's latent space can't be sampled, and how a VAE fixes it.
+- The **ELBO** objective: a reconstruction term plus a KL regularizer, in closed form.
+- The **reparameterization trick** that lets gradients flow through a random sample.
+- How Flax NNX's **explicit RNG streams** (`params` vs. `noise`) cleanly separate weight init from latent sampling.
+- Reusing shared `ConvEncoder` / `ConvDecoder` bodies for the encoder and decoder.
+:::
+
+:::info Example Code
+The complete, runnable script for this guide lives at
+[`examples/generative/vae.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/vae.py).
+:::
+
+## From autoencoder to VAE
+
+A [plain autoencoder](/applications/generative/autoencoder) maps each image to a
+single point in latent space. That's great for reconstruction, but the latent
+space is full of *holes*: pick a random point and the decoder produces garbage,
+because nothing forced nearby points to be meaningful.
+
+A **variational autoencoder** fixes this by making the encoder output a
+*distribution* instead of a point — a Gaussian $q(z \mid x) = \mathcal{N}(\mu,
+\operatorname{diag}(\sigma^2))$ — and by pulling every one of those Gaussians
+toward a shared prior $p(z) = \mathcal{N}(0, I)$. Once training packs the latent
+space against that prior, you can sample $z \sim \mathcal{N}(0, I)$ and decode it
+into a realistic new digit.
+
+## The math: the ELBO
+
+We want to maximize the likelihood $p(x)$, but the marginal is intractable.
+Instead we maximize a tractable lower bound, the **evidence lower bound (ELBO)**:
+
+$$
+\mathcal{L} = \mathbb{E}_{q(z|x)}\big[\log p(x|z)\big] - D_{KL}\big(q(z|x)\,\|\,p(z)\big)
+$$
+
+Two forces balance here:
+
+- The **reconstruction term** $\mathbb{E}_{q(z|x)}[\log p(x|z)]$ wants the decoder
+  to rebuild $x$ from its latent code. For binary/greyscale pixels we model
+  $p(x|z)$ as independent Bernoullis, so $-\log p(x|z)$ is the sigmoid
+  **binary cross-entropy** between the decoder logits and the input.
+- The **KL term** $D_{KL}(q(z|x)\|p(z))$ pulls each encoded Gaussian toward the
+  prior. For two Gaussians it has a closed form (no sampling needed):
+
+$$
+D_{KL}\big(\mathcal{N}(\mu, \sigma^2)\,\|\,\mathcal{N}(0, I)\big)
+= -\tfrac{1}{2} \sum_{j} \Big(1 + \log \sigma_j^2 - \mu_j^2 - \sigma_j^2\Big)
+$$
+
+We **minimize** the negative ELBO: `loss = recon + kl`.
+
+### The reparameterization trick
+
+To train with gradient descent we need to backprop *through* the sampling step
+$z \sim q(z|x)$ — but sampling is not differentiable. The trick is to move the
+randomness outside the parameters:
+
+$$
+z = \mu + \sigma \odot \epsilon, \qquad \epsilon \sim \mathcal{N}(0, I)
+$$
+
+Now $\mu$ and $\sigma$ are deterministic functions of the weights, $\epsilon$ is
+an external noise source, and gradients flow cleanly into the encoder. In
+practice we predict $\log \sigma^2$ (`logvar`) for numerical stability and
+recover $\sigma = \exp(\tfrac{1}{2}\log \sigma^2)$.
+
+## Why NNX explicit RNG streams matter
+
+The VAE needs randomness in **two unrelated places**: initializing weights, and
+drawing $\epsilon$ every forward pass. If they shared one stream, changing the
+model size would shift your sampling noise, and vice versa — a debugging
+nightmare. Flax NNX makes each stream a named, independent generator:
+
+```python
+rngs = nnx.Rngs(params=0, noise=1)   # weight init vs. latent sampling
+```
+
+Layers pull their init keys from the `params` stream, while our `__call__` pulls
+fresh noise from `self.rngs.noise()`. The RNG state lives *inside* the model, so
+it is tracked correctly under `nnx.jit` and advances on every call.
+
+## Building the model
+
+### Encoder: two heads for μ and log σ²
+
+The encoder reuses the shared `ConvEncoder` body — two stride-2 conv blocks that
+take a `(B, 28, 28, 1)` image down to `(B, 7, 7, 32)` — then flattens and splits
+into a `mu` head and a `logvar` head.
+
+```python
+from flax import nnx
+from shared.models import ConvEncoder, ConvDecoder
+
+class Encoder(nnx.Module):
+    def __init__(self, latent_dim: int, base: int = 16, *, rngs: nnx.Rngs):
+        self.body = ConvEncoder(1, base, rngs=rngs)   # (B,28,28,1) -> (B,7,7,base*2)
+        feat = base * 2 * 7 * 7                        # 32 * 7 * 7 = 1568
+        self.mu = nnx.Linear(feat, latent_dim, rngs=rngs)
+        self.logvar = nnx.Linear(feat, latent_dim, rngs=rngs)
+
+    def __call__(self, x):
+        h = self.body(x)
+        h = h.reshape(h.shape[0], -1)                  # flatten
+        return self.mu(h), self.logvar(h)
+```
+
+### VAE: reparameterize and decode
+
+The decoder is the shared `ConvDecoder`, which upsamples a latent vector back to
+`(B, 28, 28, 1)` **logits**. The `VAE` module ties encoder, sampling, and
+decoder together, and keeps a `sample()` helper for pure generation.
+
+```python
+import jax
+import jax.numpy as jnp
+
+class VAE(nnx.Module):
+    def __init__(self, latent_dim: int = 16, base: int = 16, *, rngs: nnx.Rngs):
+        self.latent_dim = latent_dim
+        self.encoder = Encoder(latent_dim, base, rngs=rngs)
+        self.decoder = ConvDecoder(latent_dim, base, 1, rngs=rngs)  # -> logits
+        self.rngs = rngs
+
+    def __call__(self, x):
+        mu, logvar = self.encoder(x)
+        std = jnp.exp(0.5 * logvar)
+        eps = jax.random.normal(self.rngs.noise(), mu.shape)  # external noise
+        z = mu + std * eps                                    # reparameterization
+        return self.decoder(z), mu, logvar
+
+    def sample(self, n: int, seed: int = 0):
+        z = jax.random.normal(jax.random.key(seed), (n, self.latent_dim))
+        return nnx.sigmoid(self.decoder(z))                   # logits -> [0, 1]
+```
+
+Note the decoder returns **logits** in `__call__` (so the loss can use numerically
+stable sigmoid-BCE) but `sample()` applies `nnx.sigmoid` to produce viewable
+pixels in $[0, 1]$.
+
+## The loss and train step
+
+The loss returns the negative ELBO plus its two components as auxiliary data. We
+reuse the shared `bce_loss` (summed sigmoid BCE per image) and `kl_divergence`
+(the closed-form Gaussian KL above).
+
+```python
+from shared.training_utils import bce_loss, kl_divergence
+
+def vae_loss(model, x):
+    logits, mu, logvar = model(x)
+    recon = bce_loss(logits, x)        # -E_q[log p(x|z)]
+    kl = kl_divergence(mu, logvar)     # D_KL(q(z|x) || N(0, I))
+    return recon + kl, (recon, kl)
+```
+
+The train step follows the standard NNX pattern — `nnx.value_and_grad` with
+`has_aux=True`, then `optimizer.update(model, grads)`:
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        return vae_loss(model, batch)
+
+    (loss, (recon, kl)), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, (recon, kl)
+```
+
+Wire it together with two RNG streams and Adam:
+
+```python
+import optax
+
+rngs = nnx.Rngs(params=0, noise=1)
+model = VAE(latent_dim=16, rngs=rngs)
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+## Results / What to expect
+
+The script defaults to tiny **synthetic** data (smooth Gaussian blobs, no
+downloads) so it runs offline on CPU in seconds. You should see the negative
+ELBO fall steadily as reconstruction improves while the KL term settles:
+
+```console
+$ python generative/vae.py
+epoch 1/3  ELBO loss 545.47  (recon 531.13  kl 0.51)
+epoch 2/3  ELBO loss 511.34  (recon 492.09  kl 1.00)
+epoch 3/3  ELBO loss 450.06  (recon 392.50  kl 20.26)
+generated samples: (8, 28, 28, 1)
+```
+
+Early on the KL term sits near zero (the encoder collapses to the prior while it
+learns to reconstruct); as training continues the latent code starts carrying
+information and the KL grows — exactly the reconstruction-vs-regularization
+balance the ELBO trades off.
+
+Set `SYNTHETIC=0` to train on real MNIST via `tfds`, and tune `EPOCHS` / `BATCH`
+via environment variables. On MNIST the reconstruction term dominates early, then
+the KL term grows as the latent space organizes toward the prior — after which
+`model.sample(n, seed)` yields recognizable, novel digits.
+
+## Common Pitfalls
+
+- ❌ Predicting $\sigma$ directly and taking its log (can go negative → `NaN`).
+  ✅ Predict `logvar` and use `std = jnp.exp(0.5 * logvar)`; the exp keeps $\sigma > 0$.
+
+- ❌ Sampling with `z = jax.random.normal(...)` *inside* `loss_fn` from a key you
+  reuse every step (frozen or duplicated noise).
+  ✅ Pull fresh noise from an NNX stream, `self.rngs.noise()`, so each call advances
+  the RNG state and `nnx.jit` tracks it.
+
+- ❌ Applying `sigmoid` before the loss and then using BCE (double sigmoid, unstable).
+  ✅ Keep the decoder's `__call__` output as **logits** and feed them to sigmoid-BCE;
+  only apply `nnx.sigmoid` when you want images to look at.
+
+- ❌ Dropping the KL term (or averaging BCE over pixels while summing KL). The two
+  terms end up on wildly different scales and the model ignores the prior.
+  ✅ Sum BCE over pixels and sum KL over latent dims, then average both over the
+  batch — as the shared `bce_loss` and `kl_divergence` do.
+
+- ❌ Sharing one RNG stream for weights and sampling (`nnx.Rngs(0)`), so resizing
+  the model silently changes your noise.
+  ✅ Use named streams: `nnx.Rngs(params=0, noise=1)`.
+
+## Next steps
+
+- [Generative Adversarial Networks (GAN)](/applications/generative/gan) — learn the
+  data density *implicitly* with an adversarial game instead of an explicit ELBO.
+- [Diffusion Models (DDPM)](/applications/generative/diffusion) — generate by
+  iteratively denoising, trading one latent draw for many refinement steps.
+
+## Complete Example
+
+The full, verified script is at
+[`examples/generative/vae.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/generative/vae.py)
+— a CPU-friendly VAE with synthetic-data defaults, ELBO training loop, and a
+`sample()` generator.
+
+## References
+
+- Kingma & Welling, *Auto-Encoding Variational Bayes* (2013). [arXiv:1312.6114](https://arxiv.org/abs/1312.6114)
+- Rezende, Mohamed & Wierstra, *Stochastic Backpropagation and Approximate Inference in Deep Generative Models* (2014). [arXiv:1401.4082](https://arxiv.org/abs/1401.4082)
+- Doersch, *Tutorial on Variational Autoencoders* (2016). [arXiv:1606.05908](https://arxiv.org/abs/1606.05908)
+- Higgins et al., *β-VAE: Learning Basic Visual Concepts with a Constrained Variational Framework* (2017). [OpenReview](https://openreview.net/forum?id=Sy2fzU9gl)

--- a/website/docs/applications/index.md
+++ b/website/docs/applications/index.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 0
+title: Flax NNX Applications — Build Real Models Across Domains
+description: A tour of small, self-contained Flax NNX implementations across generative models, sequence models, graphs, scientific ML, vision, and fine-tuning.
+keywords: [flax nnx applications, jax examples, generative models, rnn, graph neural network, pinn, lora, vision transformer, flax tutorials]
+---
+
+# Applications
+
+You've learned the fundamentals, seen the canonical architectures, and scaled a
+training run. This section is where it all pays off: **small, self-contained
+implementations of real model families you can build with Flax NNX** — each one
+runnable, each one teaching a distinct idea.
+
+Every guide here follows the same recipe: the math in a few lines, a from-scratch
+model in idiomatic NNX, a training step, and results you can reproduce. Datasets
+are tiny (MNIST, synthetic, or built-in) so everything runs on a laptop.
+
+## The domains
+
+### 🎨 [Generative Models](/applications/generative)
+Learn to *generate* data, not just classify it: autoencoders, VAEs, GANs, and
+diffusion models. Showcases `nnx.ConvTranspose` for learned upsampling.
+
+### 🔁 [Sequence Models & Time Series](/applications/sequence)
+Recurrence and order: RNNs, LSTMs, and GRUs via the `nnx.RNN` API family, plus
+sequence-to-sequence and forecasting.
+
+### 🔬 [Graphs, Scientific & Structured](/applications/scientific)
+Beyond grids and sequences: graph neural networks, physics-informed networks
+(PINNs) that differentiate *through the model*, and structured/tabular data.
+
+### 🧬 [Multimodal & Adaptation](/applications/adaptation)
+Adapt and combine models: parameter-efficient fine-tuning with LoRA
+(`nnx.LoRALinear`) and cross-modal alignment.
+
+## Prerequisites
+
+These guides assume you're comfortable with the [training loop](/basics/workflows/simple-training)
+and [Flax NNX state](/basics/fundamentals/understanding-state). Individual guides
+link the specific extra background they need.
+
+## How to use this section
+
+Each sub-category has a suggested reading order that builds one idea at a time
+(e.g. Autoencoder → VAE → GAN → Diffusion). Jump straight to a domain that
+interests you, or work through a whole track.
+
+## Next steps
+
+- Start with [Generative Models](/applications/generative) — the most popular track.
+- Or explore [Sequence Models](/applications/sequence) if you work with text or time series.
+- Need to scale one of these up? See [Distributed Training](/scale/).

--- a/website/docs/applications/index.md
+++ b/website/docs/applications/index.md
@@ -28,7 +28,12 @@ sequence-to-sequence and forecasting.
 
 ### 🔬 [Graphs, Scientific & Structured](/applications/scientific)
 Beyond grids and sequences: graph neural networks, physics-informed networks
-(PINNs) that differentiate *through the model*, and structured/tabular data.
+(PINNs) that differentiate *through the model*, Neural ODEs, tabular data, and
+mixture-of-experts.
+
+### 🖼️ [Advanced Vision](/applications/vision)
+Vision beyond CNNs: the Vision Transformer (attention on image patches) and the
+U-Net for dense per-pixel segmentation.
 
 ### 🧬 [Multimodal & Adaptation](/applications/adaptation)
 Adapt and combine models: parameter-efficient fine-tuning with LoRA

--- a/website/docs/applications/scientific/graph-neural-networks.md
+++ b/website/docs/applications/scientific/graph-neural-networks.md
@@ -1,0 +1,299 @@
+---
+sidebar_position: 1
+title: Graph Neural Networks (GCN) in Flax NNX
+description: "Build a Graph Convolutional Network in Flax NNX for semi-supervised node classification on Zachary's Karate Club using symmetric-normalized message passing."
+keywords: [graph neural network, GCN, node classification, message passing, semi-supervised learning, graph convolution, Flax NNX, JAX, Zachary karate club]
+---
+
+# Graph Neural Networks with GCN
+
+Classify every member of a social network into their faction — from just **two**
+labeled examples — by letting each node learn from its neighbors.
+
+:::note Prerequisites
+You should be comfortable building modules in [Your First Model](/basics/fundamentals/your-first-model)
+and running a [Simple Training Loop](/basics/workflows/simple-training). No prior
+graph-theory background is required — we build the graph from scratch.
+:::
+
+:::tip What you'll learn
+- How **message passing** turns a graph into a differentiable layer
+- Build the symmetric-normalized adjacency $\hat A = \tilde D^{-1/2}(A+I)\tilde D^{-1/2}$
+- Implement a `GCNLayer` with `nnx.Linear` for the weight and an `einsum` for neighborhood aggregation
+- Train **semi-supervised**: cross-entropy on 2 labeled nodes, evaluated on all 34
+- Recover the real community split at ~97% accuracy in under 100 steps
+:::
+
+:::info Example Code
+See the full implementation: [`examples/scientific/gcn_karate.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/gcn_karate.py)
+:::
+
+## Why graphs?
+
+Images live on grids and text lives in sequences, but a huge amount of the
+world is **relational**: social networks, molecules, citation graphs, road
+maps. These have no fixed size and no natural ordering — a convolution or an
+RNN has nothing to slide along.
+
+A **Graph Neural Network (GNN)** operates directly on the connectivity. The core
+idea is **message passing**: every node repeatedly updates its representation by
+aggregating the representations of its neighbors. After $L$ rounds, a node's
+embedding summarizes its $L$-hop neighborhood, and nearby nodes end up with
+similar embeddings — exactly the signal we need to separate communities.
+
+We'll use **Zachary's Karate Club**: 34 members, 78 friendship edges, and a
+famous real-world split into two factions after a dispute between the instructor
+(node 0) and the administrator (node 33). We reveal only those two leaders'
+labels and ask the GCN to classify everyone else.
+
+## The math: neighborhood aggregation
+
+A single graph-convolution layer transforms node features $H^{(l)} \in
+\mathbb{R}^{N \times d_l}$ into $H^{(l+1)}$ with the propagation rule from
+Kipf & Welling:
+
+$$
+H^{(l+1)} = \sigma\!\left( \hat A \, H^{(l)} \, W^{(l)} \right)
+$$
+
+Reading it right-to-left:
+
+- $H^{(l)} W^{(l)}$ — a learnable linear transform of every node's features (the weight $W^{(l)}$).
+- $\hat A \,(\cdot)$ — **aggregation**: each node's new vector is a weighted sum over its neighbors' transformed vectors.
+- $\sigma$ — a nonlinearity (ReLU).
+
+The aggregation matrix $\hat A$ is the **symmetric-normalized adjacency with
+self-loops**:
+
+$$
+\hat A = \tilde D^{-1/2}\,(A + I)\,\tilde D^{-1/2},
+\qquad
+\tilde D_{ii} = \sum_j (A + I)_{ij}
+$$
+
+Two design choices matter here:
+
+- **Self-loops** ($A + I$) let a node keep its own features, not just its neighbors'.
+- **Symmetric normalization** ($\tilde D^{-1/2}\cdots\tilde D^{-1/2}$) stops high-degree hubs from dominating and keeps activations well-scaled across layers.
+
+For node $i$, one layer computes, elementwise:
+
+$$
+h_i^{(l+1)} = \sigma\!\Big( \sum_{j \in \mathcal{N}(i)\cup\{i\}} \frac{1}{\sqrt{\tilde d_i \tilde d_j}}\, W^{(l)\top} h_j^{(l)} \Big)
+$$
+
+## Building the graph
+
+We hardcode the standard 78 undirected edges, build the binary adjacency, add
+self-loops, and symmetric-normalize. This is a pure NumPy/JAX preprocessing step
+— no parameters:
+
+```python
+import jax.numpy as jnp
+
+NUM_NODES = 34
+
+def normalize_adjacency(edges, num_nodes: int):
+    a = jnp.zeros((num_nodes, num_nodes), dtype=jnp.float32)
+    src = jnp.array([e[0] for e in edges])
+    dst = jnp.array([e[1] for e in edges])
+    a = a.at[src, dst].set(1.0)
+    a = a.at[dst, src].set(1.0)          # undirected -> symmetric
+
+    a = a + jnp.eye(num_nodes)           # self-loops (A + I)
+    deg = a.sum(axis=1)                  # degrees of (A + I)
+    d_inv_sqrt = jnp.diag(jnp.power(deg, -0.5))
+    return d_inv_sqrt @ a @ d_inv_sqrt   # D^{-1/2} (A + I) D^{-1/2}
+```
+
+For **features** we use the identity matrix — every node is a one-hot vector of
+its own id. The GCN has no other information to go on: it must infer everything
+from the graph structure. (You could instead learn a dense feature per node with
+`nnx.Embed(34, feat)`; both work here.)
+
+## The GCN layer
+
+Each layer is one line of linear algebra: apply the weight $W$ with `nnx.Linear`
+(no bias), then aggregate over neighbors with a parameter-free `einsum` against
+the fixed $\hat A$.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+class GCNLayer(nnx.Module):
+    """One graph convolution:  H' = A_hat @ (H @ W)."""
+
+    def __init__(self, in_features: int, out_features: int, *, rngs: nnx.Rngs):
+        self.linear = nnx.Linear(in_features, out_features, use_bias=False, rngs=rngs)
+
+    def __call__(self, a_hat: jax.Array, h: jax.Array) -> jax.Array:
+        h = self.linear(h)                          # H W          -> (N, out)
+        h = jnp.einsum("ij,jf->if", a_hat, h)       # A_hat (H W)  -> (N, out)
+        return h
+```
+
+Stacking two layers turns 34-dim one-hot inputs into 2-dim class logits. The
+first layer mixes 1-hop neighborhoods; the second reaches 2 hops:
+
+```python
+NUM_CLASSES = 2
+
+class GCN(nnx.Module):
+    def __init__(self, in_features, hidden_features, num_classes, *, rngs: nnx.Rngs):
+        self.gcn1 = GCNLayer(in_features, hidden_features, rngs=rngs)
+        self.gcn2 = GCNLayer(hidden_features, num_classes, rngs=rngs)
+
+    def __call__(self, a_hat, features):
+        h = nnx.relu(self.gcn1(a_hat, features))    # (N, hidden)
+        logits = self.gcn2(a_hat, h)                # (N, num_classes)
+        return logits
+
+model = GCN(NUM_NODES, 16, NUM_CLASSES, rngs=nnx.Rngs(0))
+```
+
+## Semi-supervised training
+
+Here's the twist that makes GNNs shine: we only have labels for the **two faction
+leaders** (node 0 = Mr. Hi, node 33 = Officer). A boolean `train_mask` picks them
+out, and the loss is cross-entropy averaged over the masked nodes only:
+
+```python
+import optax
+
+def masked_cross_entropy(logits, labels, mask):
+    ce = optax.softmax_cross_entropy_with_integer_labels(logits, labels)
+    return (ce * mask).sum() / mask.sum()   # average over labeled nodes only
+```
+
+The train step is the standard NNX pattern — a full-batch pass over the whole
+graph each step, with `nnx.value_and_grad` and `optimizer.update`:
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["a_hat"], batch["features"])
+        loss = masked_cross_entropy(logits, batch["labels"], batch["train_mask"])
+        acc = jnp.mean(logits.argmax(-1) == batch["labels"])   # over ALL nodes
+        return loss, acc
+
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+for step in range(200):
+    loss, acc = train_step(model, optimizer, batch)
+```
+
+Even though gradients only flow from two labels, `A_hat` propagates that signal
+across every edge: the labels of nodes 0 and 33 diffuse through the graph, and
+the two leaders' anchors pin the orientation so class 0 stays "Mr. Hi" and class
+1 stays "Officer" (no label-flipping ambiguity).
+
+## Results / What to expect
+
+Training for 200 full-batch steps on CPU takes only a few seconds. The masked
+loss collapses toward zero and full-graph accuracy climbs to **97%** — the GCN
+recovers the true faction split, misclassifying just one boundary node:
+
+```console
+$ python scientific/gcn_karate.py
+Training GCN on Zachary's Karate Club for 200 steps (labeled anchors: nodes 0 and 33)
+
+step    0 | masked loss 0.6883 | full-graph acc 0.529
+step   20 | masked loss 0.3331 | full-graph acc 0.941
+step   40 | masked loss 0.0491 | full-graph acc 0.941
+step   60 | masked loss 0.0094 | full-graph acc 0.971
+step  100 | masked loss 0.0025 | full-graph acc 0.971
+step  199 | masked loss 0.0007 | full-graph acc 0.971
+
+Final full-graph accuracy: 0.971 (33/34 nodes)
+```
+
+Starting from ~53% (random guessing on a balanced 2-class problem), the model
+crosses 90% within 20 steps and stabilizes at 33/34 correct. The single
+persistent error is a node on the boundary between the two communities — exactly
+where even humans disagreed in the original study.
+
+## Common pitfalls
+
+**Forgetting self-loops.**
+
+❌ Normalizing $A$ alone drops each node's own features during aggregation.
+```python
+a_hat = normalize(a)          # neighbors only — node forgets itself
+```
+✅ Add the identity first so a node keeps its own signal.
+```python
+a_hat = normalize(a + jnp.eye(num_nodes))
+```
+
+**Row-normalizing instead of symmetric-normalizing.**
+
+❌ $D^{-1}A$ (a random-walk average) lets hub nodes wash out weak neighbors and
+can destabilize deep stacks.
+```python
+a_hat = jnp.diag(1.0 / deg) @ a
+```
+✅ Use the symmetric form $\tilde D^{-1/2}(A+I)\tilde D^{-1/2}$.
+```python
+d = jnp.diag(jnp.power(deg, -0.5))
+a_hat = d @ (a + jnp.eye(n)) @ d
+```
+
+**Computing the loss over every node.**
+
+❌ In a semi-supervised setting you don't have all the labels — averaging over
+all 34 leaks the answer and defeats the point.
+```python
+loss = softmax_cross_entropy(logits, labels).mean()   # uses all labels!
+```
+✅ Mask the loss to the few labeled nodes.
+```python
+loss = (ce * train_mask).sum() / train_mask.sum()
+```
+
+**Putting a bias in the graph-conv weight.**
+
+❌ A bias term is redundant with the aggregation and muddies the message-passing math.
+```python
+self.linear = nnx.Linear(d_in, d_out, rngs=rngs)        # use_bias=True
+```
+✅ Disable it; $\hat A$ already provides the affine mixing.
+```python
+self.linear = nnx.Linear(d_in, d_out, use_bias=False, rngs=rngs)
+```
+
+**Passing plain Python lists of submodules to NNX.**
+
+❌ A bare list of layers won't register as state and crashes on Flax 0.12.
+```python
+self.layers = [GCNLayer(...), GCNLayer(...)]
+```
+✅ Wrap submodule collections in `nnx.List`.
+```python
+self.layers = nnx.List([GCNLayer(...), GCNLayer(...)])
+```
+
+## Next steps
+
+- [Physics-Informed Neural Networks (PINN)](/applications/scientific/pinn) — another
+  scientific-ML pattern where JAX autodiff, not a dataset, does the heavy lifting.
+- [Custom Training Loops](/research/custom-training-loops) — deepen the training
+  patterns used here.
+
+## Complete Example
+
+[`examples/scientific/gcn_karate.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/gcn_karate.py)
+— the full, runnable GCN with hardcoded graph, symmetric normalization, and the
+semi-supervised training loop.
+
+## References
+
+- Kipf & Welling (2017), *Semi-Supervised Classification with Graph Convolutional Networks* — [arXiv:1609.02907](https://arxiv.org/abs/1609.02907)
+- Hamilton, Ying & Leskovec (2017), *Inductive Representation Learning on Large Graphs (GraphSAGE)* — [arXiv:1706.02216](https://arxiv.org/abs/1706.02216)
+- Veličković et al. (2018), *Graph Attention Networks* — [arXiv:1710.10903](https://arxiv.org/abs/1710.10903)
+- Gilmer et al. (2017), *Neural Message Passing for Quantum Chemistry* — [arXiv:1704.01212](https://arxiv.org/abs/1704.01212)

--- a/website/docs/applications/scientific/index.md
+++ b/website/docs/applications/scientific/index.md
@@ -20,9 +20,12 @@ stage.
 - **[Physics-Informed Neural Networks (PINN)](/applications/scientific/pinn)** —
   solve a differential equation by baking it into the loss, differentiating the
   network's *output with respect to its input* via `jax.grad`. No dataset needed.
-
-More guides in this track (Neural ODEs, tabular deep learning, and mixture of
-experts) are on the way.
+- **[Neural ODEs](/applications/scientific/neural-ode)** — continuous-depth models;
+  learn the *dynamics* and integrate them through a differentiable ODE solver.
+- **[Tabular Deep Learning](/applications/scientific/tabular)** — MLPs with
+  categorical embeddings for structured/tabular data (classification and regression).
+- **[Mixture of Experts (MoE)](/applications/scientific/mixture-of-experts)** —
+  sparse conditional computation with top-k routing and a load-balancing loss.
 
 ## Prerequisites
 

--- a/website/docs/applications/scientific/index.md
+++ b/website/docs/applications/scientific/index.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 0
+title: Graphs, Scientific & Structured Data in Flax NNX
+description: Build graph neural networks and physics-informed neural networks (PINNs) in Flax NNX — new data modalities and differentiating through the model with JAX autodiff.
+keywords: [graph neural network, GCN, physics-informed neural network, PINN, scientific machine learning, flax nnx, jax autodiff]
+---
+
+# Graphs, Scientific & Structured
+
+Grids (images) and sequences (text) aren't the only structures worth modeling.
+This track ventures into **relational data (graphs)** and **scientific ML**,
+where JAX's real superpower — differentiating arbitrary functions — takes center
+stage.
+
+## What you'll build
+
+- **[Graph Neural Networks (GCN)](/applications/scientific/graph-neural-networks)** —
+  message passing over a graph for semi-supervised node classification, using
+  `nnx.Einsum` for adjacency-weighted aggregation.
+- **[Physics-Informed Neural Networks (PINN)](/applications/scientific/pinn)** —
+  solve a differential equation by baking it into the loss, differentiating the
+  network's *output with respect to its input* via `jax.grad`. No dataset needed.
+
+More guides in this track (Neural ODEs, tabular deep learning, and mixture of
+experts) are on the way.
+
+## Prerequisites
+
+You should be comfortable with the [training loop](/basics/workflows/simple-training)
+and [custom training loops](/research/custom-training-loops). PINNs assume basic
+calculus (derivatives, differential equations).
+
+## Next steps
+
+- Start with [Graph Neural Networks](/applications/scientific/graph-neural-networks).
+- Then try [Physics-Informed Neural Networks](/applications/scientific/pinn).

--- a/website/docs/applications/scientific/mixture-of-experts.md
+++ b/website/docs/applications/scientific/mixture-of-experts.md
@@ -1,0 +1,317 @@
+---
+sidebar_position: 5
+title: Mixture of Experts (MoE) in Flax NNX
+description: "Build a sparse Mixture-of-Experts layer in Flax NNX with a learnable gate, top-k routing, and a load-balancing auxiliary loss on a synthetic task."
+keywords: [mixture of experts, MoE, sparse routing, top-k gating, load balancing, conditional computation, expert networks, Flax NNX, JAX]
+---
+
+# Mixture of Experts
+
+Route each input to a handful of specialist sub-networks with a learnable gate,
+and keep those specialists busy with a load-balancing loss.
+
+:::note Prerequisites
+You should be comfortable training a classifier — see
+[Tabular Data with MLPs](/applications/scientific/tabular) — and be able to write
+your own [Custom Training Loops](/research/custom-training-loops). The residual
+block structure mirrors the feed-forward layer in a
+[Simple Transformer](/basics/text/simple-transformer).
+:::
+
+:::tip What you'll learn
+- Why **conditional computation** lets you grow model capacity without growing per-input FLOPs
+- Implement a `MoELayer` with a linear **gate**, `jax.lax.top_k` routing, and an `nnx.List` of expert MLPs
+- Combine the chosen experts' outputs with a masked `einsum`
+- Add a **load-balancing auxiliary loss** so the gate can't collapse onto one expert
+- Return the auxiliary loss and **expert utilization** through `has_aux` and read the routing histogram
+:::
+
+:::info Example Code
+See the full implementation: [`examples/scientific/moe.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/moe.py)
+:::
+
+## Why mixture of experts?
+
+A dense network runs *every* parameter on *every* input. If you want more
+capacity, you pay for it on every forward pass. **Mixture of Experts (MoE)**
+breaks that link: you keep a pool of $E$ expert sub-networks but a lightweight
+**gate** activates only $k \ll E$ of them per input. Capacity scales with $E$;
+compute scales with $k$. This is the trick behind the largest sparse language
+models, where MoE feed-forward layers replace the dense FFN inside each
+transformer block.
+
+The intuition is **specialization**. Different regions of input space have
+different structure — different classes, different regimes, different languages.
+Rather than force one network to model all of them, the gate learns a soft
+partition and lets each expert become good at its slice.
+
+We demonstrate this on a synthetic Gaussian-mixture classification task: several
+well-separated blobs, each its own class. That piecewise structure is exactly
+what a set of experts can carve up.
+
+## The math: top-k routing
+
+Given an input representation $x \in \mathbb{R}^{d}$, a linear gate produces one
+logit per expert:
+
+$$
+g = W_g\, x \in \mathbb{R}^{E}
+$$
+
+We keep only the $k$ largest logits. Let $\mathcal{T}(x)$ be the set of top-$k$
+expert indices. The **combine weights** are a softmax taken over just those $k$
+logits:
+
+$$
+p_e = \frac{\exp(g_e)}{\sum_{j \in \mathcal{T}(x)} \exp(g_j)}
+\quad\text{for } e \in \mathcal{T}(x), \qquad p_e = 0 \text{ otherwise.}
+$$
+
+The layer output is the weighted sum of the selected experts' outputs (all other
+experts contribute nothing):
+
+$$
+y = \sum_{e \in \mathcal{T}(x)} p_e \; \mathrm{Expert}_e(x)
+$$
+
+Because $p_e = 0$ outside the top-$k$ set, this is genuinely **sparse
+computation** — even though, for simplicity on CPU, our code evaluates all
+experts and masks the rest.
+
+## The math: load balancing
+
+Left alone, the gate finds a shortcut: send everything to one strong expert,
+let the others wither. To prevent that collapse we add an auxiliary
+**load-balancing loss** (Switch-Transformer style). For a batch, define per
+expert $i$:
+
+- $f_i$ — the fraction of routing slots assigned to expert $i$ (there are $B\cdot k$ slots in a batch of $B$),
+- $P_i$ — the mean gate probability mass on expert $i$ (from the full softmax over all experts).
+
+Both vectors sum to $1$. The auxiliary loss is their dot product, scaled by $E$:
+
+$$
+\mathcal{L}_{\text{balance}} = E \sum_{i=1}^{E} f_i \, P_i
+$$
+
+This is minimized (value $1$) when load is spread **uniformly** and grows toward
+$E$ as routing concentrates. Multiplying $f_i$ (a hard count) by $P_i$ (a smooth
+probability) keeps the term differentiable through the gate. The total objective
+is the task loss plus a small multiple of the balance term:
+
+$$
+\mathcal{L} = \mathcal{L}_{\text{task}} + \alpha \, \mathcal{L}_{\text{balance}},
+\qquad \alpha = 0.01
+$$
+
+## The MoE layer
+
+The gate is a bias-free `nnx.Linear`; the experts are independent MLPs held in an
+`nnx.List` (a plain Python list would not register as state on Flax 0.12). We run
+every expert densely, then mask by the top-$k$ selection with two `einsum`s — one
+to scatter the combine weights onto a dense $(B, E)$ gate matrix, one to blend the
+expert outputs.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from shared.models import MLP
+
+class MoELayer(nnx.Module):
+    def __init__(self, d_model, d_hidden, n_experts, k, *, rngs: nnx.Rngs):
+        self.n_experts = n_experts
+        self.k = k
+        self.gate = nnx.Linear(d_model, n_experts, use_bias=False, rngs=rngs)
+        self.experts = nnx.List([                       # nnx.List, not [ ]
+            MLP(d_model, d_hidden, d_model, n_layers=2, rngs=rngs)
+            for _ in range(n_experts)
+        ])
+
+    def __call__(self, x, train: bool = False):
+        gate_logits = self.gate(x)                          # (B, E)
+        router_probs = jax.nn.softmax(gate_logits, axis=-1) # (B, E) full softmax
+
+        # top-k routing
+        top_vals, top_idx = jax.lax.top_k(gate_logits, self.k)  # (B, k)
+        top_gates = jax.nn.softmax(top_vals, axis=-1)           # (B, k)
+        one_hot = jax.nn.one_hot(top_idx, self.n_experts)       # (B, k, E)
+        dense_gates = jnp.einsum("bk,bke->be", top_gates, one_hot)  # (B, E)
+
+        # run every expert, then combine the selected ones
+        expert_out = jnp.stack(
+            [expert(x, train=train) for expert in self.experts], axis=1
+        )                                                       # (B, E, d_model)
+        y = jnp.einsum("be,bed->bd", dense_gates, expert_out)   # (B, d_model)
+
+        # load-balancing statistics
+        selection = one_hot.sum(axis=1)                         # (B, E) in {0,1}
+        f = selection.sum(axis=0) / (x.shape[0] * self.k)       # (E,) sums to 1
+        p = router_probs.mean(axis=0)                           # (E,) sums to 1
+        balance_loss = self.n_experts * jnp.sum(f * p)          # =1 when uniform
+
+        return y, balance_loss, f
+```
+
+`jax.lax.top_k` returns integer indices (no gradient), but the combine weights
+flow through `top_gates = softmax(top_vals)`, so the gate is trained end-to-end.
+Experts that aren't selected are multiplied by zero and receive no gradient for
+that input.
+
+## The classifier
+
+We wrap the MoE layer transformer-style: a stem projects the input, a **residual**
+connection wraps the MoE block, a `LayerNorm` stabilizes it, and a linear head
+produces class logits. The forward pass threads the balance loss and utilization
+back out alongside the logits.
+
+```python
+class MoEClassifier(nnx.Module):
+    def __init__(self, in_features, d_model, d_hidden, n_experts, k, n_classes, *, rngs):
+        self.stem = nnx.Linear(in_features, d_model, rngs=rngs)
+        self.moe = MoELayer(d_model, d_hidden, n_experts, k, rngs=rngs)
+        self.norm = nnx.LayerNorm(d_model, rngs=rngs)
+        self.head = nnx.Linear(d_model, n_classes, rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        h = nnx.relu(self.stem(x))                  # (B, d_model)
+        moe_out, balance_loss, util = self.moe(h, train=train)
+        h = self.norm(h + moe_out)                  # residual around the MoE block
+        logits = self.head(h)                       # (B, n_classes)
+        return logits, balance_loss, util
+
+model = MoEClassifier(32, 64, 128, n_experts=4, k=2, n_classes=6, rngs=nnx.Rngs(0))
+```
+
+## The train step
+
+The total loss is task cross-entropy plus a small multiple of the balance loss.
+Because the model returns three things, we bundle the extras into the `has_aux`
+tuple so `nnx.value_and_grad` differentiates only the scalar total:
+
+```python
+import optax
+
+AUX_COEF = 0.01
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits, balance_loss, util = model(batch["x"], train=True)
+        ce = optax.softmax_cross_entropy_with_integer_labels(logits, batch["y"]).mean()
+        total = ce + AUX_COEF * balance_loss
+        return total, (ce, balance_loss, util)
+
+    (total, (ce, balance_loss, util)), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return total, ce, balance_loss, util
+
+optimizer = nnx.Optimizer(model, optax.adam(3e-3), wrt=nnx.Param)
+for step in range(300):
+    total, ce, bal, util = train_step(model, optimizer, batch)
+```
+
+## Results / What to expect
+
+Training a top-2-of-4 MoE on the synthetic 6-class mixture takes a few seconds on
+CPU. Task cross-entropy collapses toward zero and accuracy hits 100%, while the
+balance loss hovers near its floor of $1.0$ — the sign of an evenly loaded gate:
+
+```console
+$ python scientific/moe.py
+Training a top-2-of-4 MoE classifier for 300 steps (6 classes, batch 512)
+
+step    0 | total 2.2347 | ce 2.2194 | balance 1.532 | acc 0.646
+step   50 | total 0.0107 | ce 0.0007 | balance 0.999 | acc 1.000
+step  100 | total 0.0103 | ce 0.0004 | balance 0.991 | acc 1.000
+step  150 | total 0.0102 | ce 0.0003 | balance 0.989 | acc 1.000
+step  200 | total 0.0102 | ce 0.0003 | balance 0.988 | acc 1.000
+step  250 | total 0.0101 | ce 0.0002 | balance 0.985 | acc 1.000
+step  299 | total 0.0100 | ce 0.0002 | balance 0.983 | acc 1.000
+
+Final expert utilization (fraction of routing slots):
+  e0:0.26  e1:0.23  e2:0.26  e3:0.25
+```
+
+The utilization histogram is the diagnostic to watch: each expert handles roughly
+$1/E = 0.25$ of the routing slots. If you drop `AUX_COEF` to `0.0`, the same run
+tends to concentrate mass on one or two experts (utilization like
+`e0:0.5 e1:0.4 e2:0.05 e3:0.05`) — capacity you paid for but never use.
+
+## Common pitfalls
+
+**Plain Python list of experts.**
+
+❌ A bare list won't register as state and crashes on Flax 0.12.
+```python
+self.experts = [MLP(...) for _ in range(n_experts)]
+```
+✅ Wrap the expert collection in `nnx.List`.
+```python
+self.experts = nnx.List([MLP(...) for _ in range(n_experts)])
+```
+
+**No load-balancing loss.**
+
+❌ Task loss alone lets the gate collapse onto one expert; the rest go dead.
+```python
+total = ce                                  # gate collapses over time
+```
+✅ Add the balance term so usage stays spread out.
+```python
+total = ce + AUX_COEF * balance_loss
+```
+
+**Softmaxing over all experts for the combine weights.**
+
+❌ A full softmax leaks probability mass onto experts you didn't select.
+```python
+weights = jax.nn.softmax(gate_logits, axis=-1)   # (B, E) — not sparse
+```
+✅ Softmax over the top-k logits only, then scatter back.
+```python
+top_vals, top_idx = jax.lax.top_k(gate_logits, k)
+top_gates = jax.nn.softmax(top_vals, axis=-1)    # (B, k)
+```
+
+**Trying to backprop through the routing indices.**
+
+❌ `top_idx` is integer-valued and has no gradient — routing there is a no-op.
+```python
+loss = something(top_idx)                   # gate never learns
+```
+✅ Let gradients flow through the softmax **weights**, not the indices.
+```python
+y = jnp.einsum("be,bed->bd", dense_gates, expert_out)   # dense_gates carries grad
+```
+
+**A huge `AUX_COEF`.**
+
+❌ Over-weighting balance forces perfectly uniform routing and kills specialization.
+```python
+total = ce + 1.0 * balance_loss             # gate ignores the input
+```
+✅ Keep it small (≈0.01) — a nudge, not the objective.
+```python
+total = ce + 0.01 * balance_loss
+```
+
+## Next steps
+
+- [Neural ODEs](/applications/scientific/neural-ode) — another way to add capacity
+  through structure rather than raw width.
+- [GPT from scratch](/architectures/gpt) — where MoE layers replace the dense FFN
+  inside each transformer block at scale.
+
+## Complete Example
+
+[`examples/scientific/moe.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/moe.py)
+— the full, runnable MoE classifier: gate, top-k routing, `nnx.List` of expert
+MLPs, load-balancing loss, and the utilization readout.
+
+## References
+
+- Shazeer et al. (2017), *Outrageously Large Neural Networks: The Sparsely-Gated Mixture-of-Experts Layer* — [arXiv:1701.06538](https://arxiv.org/abs/1701.06538)
+- Fedus, Zoph & Shazeer (2021), *Switch Transformers: Scaling to Trillion Parameter Models with Simple and Efficient Sparsity* — [arXiv:2101.03961](https://arxiv.org/abs/2101.03961)
+- Lepikhin et al. (2020), *GShard: Scaling Giant Models with Conditional Computation and Automatic Sharding* — [arXiv:2006.16668](https://arxiv.org/abs/2006.16668)
+- Zoph et al. (2022), *ST-MoE: Designing Stable and Transferable Sparse Expert Models* — [arXiv:2202.08906](https://arxiv.org/abs/2202.08906)

--- a/website/docs/applications/scientific/neural-ode.md
+++ b/website/docs/applications/scientific/neural-ode.md
@@ -1,0 +1,234 @@
+---
+sidebar_position: 3
+title: "Neural ODEs in Flax NNX: Learn a Vector Field"
+description: "Fit a 2D spiral with a Neural ODE in Flax NNX — learn continuous-depth dynamics dy/dt = f(y), integrate with a hand-written RK4 solver, and backprop through it."
+keywords: [neural ode, continuous depth, flax nnx, jax, rk4 solver, differentiable ode solver, lax.scan, dynamics learning, scientific machine learning, spiral trajectory]
+---
+
+# Neural Ordinary Differential Equations
+
+**Instead of stacking a fixed number of layers, learn the *velocity* of a state and let a solver do the depth.** The network becomes a continuous-time dynamical system.
+
+:::note Prerequisites
+You should have met differential-equation losses in the [PINN guide](/applications/scientific/pinn) and be comfortable writing your own loop ([custom training loops](/research/custom-training-loops)). Familiarity with `jax.lax.scan` helps but is not required.
+:::
+
+:::tip What you'll learn
+- How a **Neural ODE** replaces layer count with a learned vector field $f_\theta(y)$ and a numerical solver
+- How to hand-write a **fixed-step RK4 integrator** with `jax.lax.scan` — no `diffrax` dependency
+- What **"discretize-then-optimize"** means: backprop straight through the unrolled solver
+- How to fit an entire **trajectory** (not point labels) with a plain MSE loss
+- Why **zero-initializing the dynamics** keeps an untrained solver from blowing up
+:::
+
+:::info Example Code
+See the full implementation: [`examples/scientific/neural_ode.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/neural_ode.py)
+:::
+
+## From layers to a vector field
+
+A residual block computes $y_{n+1} = y_n + f_\theta(y_n)$. Squint at that and it is one **Euler step** of a differential equation with step size $1$. A *Neural ODE* takes the limit seriously: instead of a discrete stack of blocks, it defines a continuous-depth state $y(t)$ whose velocity is a neural network,
+
+$$
+\frac{dy}{dt} = f_\theta(t, y), \qquad y(0) = y_0 .
+$$
+
+The "output" is the state at some later time $T$, obtained by **integrating** the field:
+
+$$
+y(T) = y_0 + \int_0^T f_\theta(t, y(t))\, dt .
+$$
+
+Depth is now a continuous variable, and the number of function evaluations is chosen by the *solver*, not baked into the architecture. Our field is autonomous ($f_\theta(y)$, no explicit $t$ dependence), which is all a spiral needs — but the solver signature keeps $t$ so you can drop in a non-autonomous field.
+
+## The task: recover a spiral
+
+To have a ground truth we can score against, we manufacture data from a **known** linear ODE whose solution is a decaying spiral:
+
+$$
+\frac{dy}{dt} = A y, \qquad
+A = \begin{bmatrix} -0.1 & -1.0 \\ 1.0 & -0.1 \end{bmatrix},
+\qquad y_0 = \begin{bmatrix} 2 \\ 0 \end{bmatrix}.
+$$
+
+The eigenvalues of $A$ are $-0.1 \pm i$: the imaginary part rotates (period $\approx 2\pi$), the negative real part pulls the radius inward. Integrating $A$ over $t \in [0, 8]$ gives a spiral of about $1.25$ turns. **The network never sees $A$** — only the sampled trajectory it produces.
+
+## The solver: fixed-step RK4 by hand
+
+Rather than pull in a solver library, we write the classic fourth-order Runge–Kutta step. For a step of size $h$ from $(t, y)$:
+
+$$
+\begin{aligned}
+k_1 &= f(t, y), & k_2 &= f\!\left(t + \tfrac{h}{2},\, y + \tfrac{h}{2}k_1\right), \\
+k_3 &= f\!\left(t + \tfrac{h}{2},\, y + \tfrac{h}{2}k_2\right), & k_4 &= f(t + h,\, y + h\,k_3), \\
+\end{aligned}
+$$
+$$
+y_{n+1} = y_n + \frac{h}{6}\left(k_1 + 2k_2 + 2k_3 + k_4\right).
+$$
+
+`jax.lax.scan` runs the loop as a single compiled, **differentiable** op. Because the whole unrolled solver is just JAX primitives, reverse-mode AD flows gradients through every step — this is the **discretize-then-optimize** approach (differentiate the numerical scheme, as opposed to solving a separate adjoint ODE).
+
+```python
+import jax
+import jax.numpy as jnp
+
+def rk4_step(f, y, t, dt):
+    """One Runge-Kutta 4 step of dy/dt = f(t, y)."""
+    k1 = f(t, y)
+    k2 = f(t + dt / 2, y + dt / 2 * k1)
+    k3 = f(t + dt / 2, y + dt / 2 * k2)
+    k4 = f(t + dt, y + dt * k3)
+    return y + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+
+def odeint_rk4(f, y0, ts):
+    """Integrate dy/dt = f(t, y) over the grid `ts`, returning states (T, ...)."""
+    dt = ts[1] - ts[0]
+
+    def step(y, t):
+        y_next = rk4_step(f, y, t, dt)
+        return y_next, y_next
+
+    _, ys = jax.lax.scan(step, y0, ts[:-1])
+    return jnp.concatenate([y0[None], ys], axis=0)
+```
+
+## The model
+
+The learned dynamics is a small MLP $f_\theta : \mathbb{R}^2 \to \mathbb{R}^2$ with a smooth (`gelu`) activation. The `NeuralODE` module simply plugs that field into the solver. One important detail: we **zero the output layer** so the initial field is $\approx 0$. An untrained random field integrated over dozens of steps can blow up (an initial trajectory MSE in the *thousands*); starting from the identity flow keeps things tame.
+
+```python
+from flax import nnx
+from shared.models import MLP   # in-repo reusable MLP
+
+class NeuralODE(nnx.Module):
+    """Continuous-depth model: an MLP dynamics f_theta(y) plugged into RK4."""
+
+    def __init__(self, hidden: int = 64, *, rngs: nnx.Rngs):
+        self.func = MLP(
+            in_features=2, hidden_features=hidden, out_features=2,
+            n_layers=3, rngs=rngs, activation="gelu",
+        )
+        # Start from the identity flow: zero the final layer so f_theta(y) ~ 0.
+        self.func.output.kernel[...] = jnp.zeros_like(self.func.output.kernel[...])
+        self.func.output.bias[...] = jnp.zeros_like(self.func.output.bias[...])
+
+    def dynamics(self, t, y):
+        """Learned vector field; autonomous, so the time input is unused."""
+        return self.func(y)
+
+    def __call__(self, y0, ts):
+        """Integrate the learned field from y0 over ts -> trajectory (T, 2)."""
+        return odeint_rk4(self.dynamics, y0, ts)
+```
+
+## Fitting a trajectory
+
+There are no `(x, y)` labels here — the supervision is an entire **trajectory**. We integrate the learned field from the same $y_0$ over the same time grid and minimize the mean-squared error against the observed spiral:
+
+$$
+\mathcal{L}(\theta) = \frac{1}{T}\sum_{i=1}^{T} \big\lVert \hat y_\theta(t_i) - y^{\text{true}}(t_i) \big\rVert^2 .
+$$
+
+The train step is the standard NNX pattern; the only twist is that `batch` carries the initial state, the time grid, and the target trajectory:
+
+```python
+import optax
+from shared.training_utils import compute_mse_loss
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    y0, ts, target = batch
+
+    def loss_fn(model):
+        pred = model(y0, ts)                 # (T, 2)
+        loss = compute_mse_loss(pred, target)
+        return loss, pred
+
+    (loss, pred), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, pred
+```
+
+The driver builds the ground-truth spiral once (by integrating the known $A$ with the *same* RK4 routine) and then runs Adam:
+
+```python
+# The known linear ODE that generates the ground-truth spiral.
+A_true = jnp.array([[-0.1, -1.0], [1.0, -0.1]])
+def true_dynamics(t, y):
+    return y @ A_true.T                          # dy/dt = A y
+
+y0 = jnp.array([2.0, 0.0])
+rngs = nnx.Rngs(0)
+model = NeuralODE(hidden=64, rngs=rngs)
+optimizer = nnx.Optimizer(model, optax.adam(5e-3), wrt=nnx.Param)
+
+ts = jnp.linspace(0.0, 8.0, 80)
+true_traj = odeint_rk4(true_dynamics, y0, ts)   # (80, 2) — the observations
+batch = (y0, ts, true_traj)
+
+for step in range(1000):
+    loss, _ = train_step(model, optimizer, batch)
+```
+
+## Results / What to expect
+
+On CPU this runs in a few seconds. Thanks to the zero-init, the trajectory MSE starts around $2.7$ (the network holds still at $y_0$) and falls by roughly *six orders of magnitude* — with small Adam wiggles — as the field learns to curl into a spiral:
+
+```console
+$ python scientific/neural_ode.py
+Fitting dy/dt = f_theta(y) to a spiral on t in [0, 8.0]
+steps=1000  points=80
+
+step     0 | trajectory MSE 2.7076e+00
+step   100 | trajectory MSE 7.9094e-04
+step   200 | trajectory MSE 1.9140e-04
+step   300 | trajectory MSE 7.7715e-05
+step   400 | trajectory MSE 3.5219e-05
+step   500 | trajectory MSE 2.0120e-05
+step   600 | trajectory MSE 1.0311e-05
+step   700 | trajectory MSE 7.3010e-05
+step   800 | trajectory MSE 4.4379e-06
+step   900 | trajectory MSE 2.9155e-06
+step   999 | trajectory MSE 2.3754e-05
+
+final trajectory MSE = 4.6880e-06
+endpoint error |y_pred(T) - y_true(T)| = 0.0055
+```
+
+The learned field reproduces the spiral to a final MSE of about $5\times10^{-6}$, and the predicted endpoint lands within $\sim 0.006$ of the true one — all without ever being told the generating matrix $A$.
+
+Scale the run with environment variables: `EPOCHS` (optimization steps) and `BATCH` (number of points sampled along the trajectory).
+
+## Common Pitfalls
+
+- ❌ **A random, un-scaled initial field.** Integrating an untrained network over dozens of RK4 steps can make the state explode (initial MSE in the thousands, sometimes `NaN`).
+  ✅ **Zero the last layer** of the dynamics so $f_\theta(y)\approx 0$ at init — start from the identity flow, as above.
+
+- ❌ **A `for` loop in Python over time steps.** Unrolling by hand is slow to trace and won't fuse.
+  ✅ Use **`jax.lax.scan`**; it compiles the whole integration into one differentiable op.
+
+- ❌ **Mismatched time grids.** Training on a fine grid but evaluating on a coarse one (or vice-versa) changes the discretization error and the effective dynamics.
+  ✅ Integrate predictions and targets on the **same `ts`**; treat the grid as part of the model.
+
+- ❌ **A step size too large for the dynamics.** Fixed-step RK4 is only stable when $h$ resolves the fastest timescale; too big a `dt` diverges regardless of the network.
+  ✅ Pick enough points that $h$ is well below the oscillation period (here $\approx 2\pi$), or switch to an adaptive solver for stiff fields.
+
+- ❌ **A plain Python list of submodules.** `self.layers = [ ... ]` breaks the pytree machinery on Flax 0.12.
+  ✅ Wrap submodule lists in **`nnx.List([ ... ])`** (and dicts in `nnx.Dict`).
+
+## Next steps
+
+- [Graph Neural Networks](/applications/scientific/graph-neural-networks) — the other frontier of structured, physics-flavored models in this track.
+- [Meta-learning](/research/meta-learning) — where differentiating through an inner optimization loop echoes differentiating through this solver.
+
+## Complete Example
+
+[`examples/scientific/neural_ode.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/neural_ode.py) — a self-contained Neural ODE that fits a 2D spiral with a hand-written RK4 solver and reports the final trajectory MSE and endpoint error.
+
+## References
+
+- Chen, Rubanova, Bettencourt, Duvenaud. *Neural Ordinary Differential Equations.* [arXiv:1806.07366](https://arxiv.org/abs/1806.07366)
+- Kidger. *On Neural Differential Equations.* [arXiv:2202.02435](https://arxiv.org/abs/2202.02435)
+- Dupont, Doucet, Teh. *Augmented Neural ODEs.* [arXiv:1904.01681](https://arxiv.org/abs/1904.01681)
+- Rubanova, Chen, Duvenaud. *Latent ODEs for Irregularly-Sampled Time Series.* [arXiv:1907.03907](https://arxiv.org/abs/1907.03907)

--- a/website/docs/applications/scientific/pinn.md
+++ b/website/docs/applications/scientific/pinn.md
@@ -1,0 +1,215 @@
+---
+sidebar_position: 2
+title: Physics-Informed Neural Networks in Flax NNX
+description: "Solve a damped-oscillator ODE with a physics-informed neural network in Flax NNX — differentiate the model through its input with jax.grad, no dataset needed."
+keywords: [physics-informed neural network, PINN, jax autodiff, flax nnx, differential equations, scientific machine learning, damped harmonic oscillator, jax.grad, collocation points]
+---
+
+# Physics-Informed Neural Networks (PINNs)
+
+**Solve a differential equation with a neural network — and not a single training label in sight.** The equation *is* the supervision.
+
+:::note Prerequisites
+You should be comfortable building a model ([your first model](/basics/fundamentals/your-first-model)) and writing your own loop ([custom training loops](/research/custom-training-loops), [training best practices](/basics/training-best-practices)). A little calculus (derivatives, second-order ODEs) helps.
+:::
+
+:::tip What you'll learn
+- How a PINN turns a differential equation into a **loss function** with no dataset
+- How to differentiate the network's **output with respect to its input** using `jax.grad` — twice
+- Why `jax.grad(jax.grad(...))` plus `vmap` is the perfect tool for this
+- Why smooth activations (**tanh**, not ReLU) are non-negotiable for second-order physics
+- How to enforce **initial conditions** so the network learns the *right* solution
+:::
+
+:::info Example Code
+See the full implementation: [`examples/scientific/pinn_oscillator.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/pinn_oscillator.py)
+:::
+
+## This guide is different
+
+Every other guide on this site fits a model to **data**: you have inputs `x`, targets `y`, and a loss that measures the gap. Here there is no `y`. Instead you have a **law of physics** the solution must obey, and you turn *that* into the loss.
+
+The trick is that a neural network $\hat u_\theta(t)$ is a smooth, differentiable function of its input. So we can ask JAX for its derivatives **with respect to the input** $t$ and check whether they satisfy the governing equation. This is the one guide where you differentiate the *model itself*, not a loss over samples.
+
+## The problem: a damped harmonic oscillator
+
+A mass on a spring with friction obeys a second-order linear ODE:
+
+$$
+u''(t) + 2\zeta\omega\, u'(t) + \omega^2 u(t) = 0, \qquad u(0) = 1,\ \ u'(0) = 0,
+$$
+
+on $t \in [0, T]$, where $\omega$ is the natural frequency and $\zeta$ the damping ratio. For the underdamped case ($0 < \zeta < 1$) the exact solution is a decaying cosine, which we only use to *check* our network afterward:
+
+$$
+u(t) = e^{-\zeta\omega t}\left(\cos(\omega_d t) + \frac{\zeta\omega}{\omega_d}\sin(\omega_d t)\right),
+\qquad \omega_d = \omega\sqrt{1 - \zeta^2}.
+$$
+
+## From equation to loss
+
+Let $\hat u_\theta(t)$ be our network. Define the **residual** — how badly the network violates the ODE at a point $t$:
+
+$$
+r_\theta(t) = \hat u_\theta''(t) + 2\zeta\omega\, \hat u_\theta'(t) + \omega^2 \hat u_\theta(t).
+$$
+
+If $\hat u_\theta$ were the true solution, $r_\theta(t) = 0$ everywhere. So we sample a set of **collocation points** $\{t_i\}_{i=1}^N$ on $[0, T]$ (just a `linspace` — no dataset) and minimize the mean-squared residual, plus a penalty pinning down the initial conditions:
+
+$$
+\mathcal{L}(\theta) = \underbrace{\frac{1}{N}\sum_{i=1}^N r_\theta(t_i)^2}_{\text{physics}}
+\;+\; \lambda\,\underbrace{\big[(\hat u_\theta(0) - 1)^2 + \hat u_\theta'(0)^2\big]}_{\text{initial conditions}}.
+$$
+
+**The initial-condition term is not optional.** The trivial function $u \equiv 0$ also satisfies the ODE — the IC penalty is what forces the network onto the *one* solution we want.
+
+The derivatives $\hat u_\theta'$ and $\hat u_\theta''$ are computed **exactly** by automatic differentiation, not finite differences. `jax.grad` gives $\hat u_\theta'$, and `jax.grad` again gives $\hat u_\theta''$. This is why JAX is ideal for PINNs: you can differentiate through the network with respect to its input, arbitrarily many times, and compose that with `vmap` (evaluate at all collocation points) and `jit` (compile the whole thing).
+
+## The model
+
+A small MLP mapping a scalar $t$ to a scalar $u$. The activation matters: **tanh** is smooth, so its first and second derivatives are well-behaved — a ReLU network has a zero second derivative almost everywhere, which would make the physics loss meaningless.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+OMEGA = 3.0    # natural frequency
+ZETA = 0.2     # damping ratio (0 < zeta < 1)
+T = 4.0        # domain [0, T]
+W_IC = 10.0    # weight on the initial-condition term
+
+
+class PINN(nnx.Module):
+    """Scalar-in, scalar-out MLP approximating u(t)."""
+
+    def __init__(self, hidden: int = 32, n_layers: int = 4, *, rngs: nnx.Rngs):
+        layers = [nnx.Linear(1, hidden, rngs=rngs)]
+        for _ in range(n_layers - 1):
+            layers.append(nnx.Linear(hidden, hidden, rngs=rngs))
+        self.layers = nnx.List(layers)          # nnx.List, not a plain list!
+        self.out = nnx.Linear(hidden, 1, rngs=rngs)
+
+    def __call__(self, t):
+        x = t
+        for layer in self.layers:
+            x = nnx.tanh(layer(x))
+        return self.out(x)
+```
+
+## The physics loss
+
+This is the heart of the method. We define a **scalar** helper `u_fn(t)` and differentiate it with respect to `t` — twice — then `vmap` the derivatives over every collocation point:
+
+```python
+def physics_loss(model, t_coll):
+    def u_fn(t):                    # scalar t -> scalar u(t)
+        return model(t.reshape(1, 1))[0, 0]
+
+    u_t_fn = jax.grad(u_fn)         # du/dt   via autodiff
+    u_tt_fn = jax.grad(u_t_fn)      # d2u/dt2 via autodiff-of-autodiff
+
+    t_flat = t_coll[:, 0]
+    u = jax.vmap(u_fn)(t_flat)
+    u_t = jax.vmap(u_t_fn)(t_flat)
+    u_tt = jax.vmap(u_tt_fn)(t_flat)
+
+    residual = u_tt + 2.0 * ZETA * OMEGA * u_t + OMEGA ** 2 * u
+    loss_res = jnp.mean(residual ** 2)
+
+    # Initial conditions u(0)=1, u'(0)=0 as a soft penalty.
+    t0 = jnp.array(0.0)
+    loss_ic = (u_fn(t0) - 1.0) ** 2 + (u_t_fn(t0) - 0.0) ** 2
+
+    total = loss_res + W_IC * loss_ic
+    return total, {"residual": loss_res, "ic": loss_ic}
+```
+
+Note the elegant separation of concerns: the **inner** `jax.grad` calls differentiate with respect to the *input* `t` (the network weights are held fixed there), while the **outer** `nnx.value_and_grad` in the train step differentiates the whole loss with respect to the *parameters*. JAX composes these nested derivatives for you.
+
+## The training step
+
+Standard NNX training step — the only unusual thing is that `batch` is just the array of collocation points, not `(x, y)` pairs:
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        total, aux = physics_loss(model, batch)
+        return total, aux
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, aux
+```
+
+And the driver — the collocation points come from a plain `linspace`, and Adam does the rest:
+
+```python
+rngs = nnx.Rngs(0)
+model = PINN(hidden=32, n_layers=4, rngs=rngs)
+optimizer = nnx.Optimizer(model, optax.adam(2e-3), wrt=nnx.Param)
+
+t_coll = jnp.linspace(0.0, T, 100).reshape(-1, 1)   # no dataset!
+
+for step in range(3000):
+    loss, aux = train_step(model, optimizer, t_coll)
+```
+
+## Results / What to expect
+
+On CPU this converges in a couple of seconds. The physics residual and IC penalty both fall by orders of magnitude, and the learned $\hat u(t)$ tracks the analytic damped cosine to within about **0.01** across the whole domain:
+
+```console
+$ python scientific/pinn_oscillator.py
+Solving u'' + 2*0.2*3.0*u' + 3.0^2*u = 0 on [0, 4.0]
+steps=3000  collocation=100
+
+step     0 | loss 1.1635e+01 | residual 5.151e-01 | ic 1.112e+00
+step   500 | loss 2.3581e-01 | residual 2.295e-01 | ic 6.289e-04
+step  1000 | loss 1.7431e-01 | residual 1.451e-01 | ic 2.919e-03
+step  1500 | loss 1.3456e-02 | residual 1.343e-02 | ic 2.544e-06
+step  2000 | loss 8.0015e-03 | residual 7.976e-03 | ic 2.577e-06
+step  2500 | loss 4.9807e-03 | residual 4.979e-03 | ic 2.122e-07
+step  2999 | loss 3.1823e-03 | residual 3.181e-03 | ic 9.729e-08
+
+max |u_pred - u_analytic| over [0, 4.0] = 0.0118
+```
+
+The network never saw the analytic solution during training — it recovered it purely from the differential equation and the two initial conditions.
+
+Run bigger or smaller with environment variables: `EPOCHS` (optimization steps), `BATCH` (number of collocation points).
+
+## Common Pitfalls
+
+- ❌ **ReLU activations.** A ReLU MLP is piecewise-linear, so its second derivative is zero almost everywhere and the physics residual becomes garbage.
+  ✅ Use a **smooth** activation like `tanh` (or `sin`, `gelu`) so `u'` and `u''` are meaningful.
+
+- ❌ **Dropping the initial-condition term.** The homogeneous ODE is also satisfied by the trivial solution $u \equiv 0$; without an IC penalty the network may happily collapse to it.
+  ✅ Add the IC penalty and **weight it** (`W_IC`) so it competes with the residual term.
+
+- ❌ **Differentiating the wrong thing.** Beginners reach for the parameter gradient when they need the *input* gradient.
+  ✅ Define a scalar `u_fn(t)` and `jax.grad` over `t`; let the outer `nnx.value_and_grad` handle the parameters.
+
+- ❌ **A plain Python list of layers.** `self.layers = [ ... ]` crashes the pytree machinery on Flax 0.12.
+  ✅ Wrap submodule lists in `nnx.List([ ... ])` (and dicts in `nnx.Dict`).
+
+- ❌ **Looping over collocation points in Python.** Calling the derivative one point at a time is painfully slow.
+  ✅ `jax.vmap` the scalar derivative over the whole batch of points at once.
+
+## Next steps
+
+- [Graph Neural Networks](/applications/scientific/graph-neural-networks) — the other frontier of "new data modalities" in this track.
+- [Custom training loops](/research/custom-training-loops) — the loop patterns underneath this example.
+- [Training best practices](/basics/training-best-practices) — for scaling PINNs to stiffer, higher-dimensional PDEs.
+
+## Complete Example
+
+[`examples/scientific/pinn_oscillator.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/pinn_oscillator.py) — a self-contained PINN that solves the damped-oscillator ODE and reports the max error against the analytic solution.
+
+## References
+
+- Raissi, Perdikaris, Karniadakis. *Physics Informed Deep Learning (Part I): Data-driven Solutions of Nonlinear Partial Differential Equations.* [arXiv:1711.10561](https://arxiv.org/abs/1711.10561)
+- Raissi, Perdikaris, Karniadakis. *Physics Informed Deep Learning (Part II): Data-driven Discovery of Nonlinear Partial Differential Equations.* [arXiv:1711.10566](https://arxiv.org/abs/1711.10566)
+- Baydin, Pearlmutter, Radul, Siskind. *Automatic Differentiation in Machine Learning: a Survey.* [arXiv:1502.05767](https://arxiv.org/abs/1502.05767)

--- a/website/docs/applications/scientific/tabular.md
+++ b/website/docs/applications/scientific/tabular.md
@@ -1,0 +1,328 @@
+---
+sidebar_position: 4
+title: Deep Learning for Tabular Data in Flax NNX
+description: "Build a tabular DNN in Flax NNX with per-column categorical embeddings concatenated with numeric features, then an MLP head for classification or regression."
+keywords: [tabular deep learning, categorical embeddings, entity embeddings, mixed features, nnx.Embed, tabular neural network, classification, regression, Flax NNX, JAX]
+---
+
+# Deep Learning for Tabular Data
+
+Turn a spreadsheet of mixed numeric and categorical columns into a differentiable
+model by giving every category its own learnable vector.
+
+:::note Prerequisites
+You should be comfortable building modules in [Your First Model](/basics/fundamentals/your-first-model)
+and running a [Simple Training Loop](/basics/workflows/simple-training). No dataset
+download is needed — the table is generated synthetically and offline.
+:::
+
+:::tip What you'll learn
+- Why raw integer category codes hurt and **entity embeddings** ($\texttt{nnx.Embed}$) fix it
+- How to give **each categorical column its own embedding table** and concatenate with numeric features
+- A clean `TabularDNN` module: embeddings → concat → MLP → head
+- Swapping a **classification head** for a **regression head** (only the head width and loss change)
+- Training with cross-entropy and watching accuracy climb from chance to ~98%
+:::
+
+:::info Example Code
+See the full implementation: [`examples/scientific/tabular_dnn.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/tabular_dnn.py)
+:::
+
+## Why tabular data is different
+
+Most real-world business data is **tabular**: rows of records with a mix of
+**numeric** columns (age, price, temperature) and **categorical** columns (city,
+device type, subscription plan). Gradient-boosted trees dominate here, but neural
+networks are attractive when you want to share a backbone across tasks, ingest
+huge cardinalities, or fuse tables with text/images.
+
+The catch is the categorical columns. A category like `city = 3` is *not*
+three-times `city = 1` — the integer code is an arbitrary label, not a
+magnitude. Feeding it as a raw float tells the network a lie about ordering and
+distance. The two classic fixes:
+
+- **One-hot encoding** — a $C$-wide sparse vector per column. Correct, but blows
+  up with high cardinality and learns nothing shared between categories.
+- **Entity embeddings** — map each category id to a small dense, *learnable*
+  vector. This is exactly what an embedding layer does for words, applied to
+  table columns. Similar categories can end up with similar vectors, and the
+  width stays small even for thousands of categories.
+
+We use entity embeddings, one table per categorical column.
+
+## The recipe: embed, concatenate, MLP
+
+For a row with numeric features $x_{\text{num}} \in \mathbb{R}^{d_{\text{num}}}$
+and categorical codes $c_1, \dots, c_K$, each column $k$ owns an embedding table
+$E_k \in \mathbb{R}^{V_k \times m_k}$ (with $V_k$ the cardinality and $m_k$ the
+embedding width). We look up each code and concatenate everything into one vector:
+
+$$
+z = \big[\, x_{\text{num}} \;\Vert\; E_1[c_1] \;\Vert\; \cdots \;\Vert\; E_K[c_K] \,\big]
+\in \mathbb{R}^{d_{\text{num}} + \sum_k m_k}
+$$
+
+That combined vector then flows through a plain MLP and a task head:
+
+$$
+h = \sigma(W_2\,\sigma(W_1 z)), \qquad \hat y = W_{\text{head}}\, h
+$$
+
+For **classification** the head outputs $C$ logits and we use softmax
+cross-entropy. For **regression** the head outputs a single scalar and we use
+mean-squared error — the only things that change are the head width and the loss.
+
+### How wide should an embedding be?
+
+A category with 3 values needs far fewer dimensions than one with 3,000. A common
+heuristic grows the width sub-linearly with cardinality (fastai uses
+$\min(600, \lceil 1.6\,V^{0.56}\rceil)$). For our tiny toy columns we use a
+small rule of thumb:
+
+```python
+def embedding_dims(cardinalities):
+    # min(8, max(2, card // 2)) per categorical column
+    return tuple(min(8, max(2, card // 2)) for card in cardinalities)
+```
+
+## The synthetic table
+
+There is no download. We generate four numeric columns (standard normal) and
+three integer-coded categorical columns, then build the label from a **hidden
+generative process** the model never sees: a nonlinear expansion of the numeric
+features (sines, a product interaction, a square) plus a random per-category
+effect table. The label is the arg-max of the resulting class scores, so the
+model must learn *both* numeric interactions and useful category embeddings.
+
+```python
+import jax
+import jax.numpy as jnp
+
+NUM_NUMERIC = 4
+CAT_CARDINALITIES = (5, 8, 3)   # one entry per categorical column
+NUM_CLASSES = 3
+
+def make_dataset(n_samples, *, seed=0, task="classification"):
+    key = jax.random.key(seed)
+    k_num, k_wnum, k_cat_eff = jax.random.split(key, 3)
+
+    x_num = jax.random.normal(k_num, (n_samples, NUM_NUMERIC))
+    cat_cols = [
+        jax.random.randint(jax.random.fold_in(key, 100 + i), (n_samples,), 0, card)
+        for i, card in enumerate(CAT_CARDINALITIES)
+    ]
+    x_cat = jnp.stack(cat_cols, axis=1).astype(jnp.int32)   # (N, n_cat)
+
+    # hidden ground truth: nonlinear numeric expansion + category effects
+    feat = jnp.concatenate([
+        x_num,
+        jnp.sin(2.0 * x_num[:, :2]),
+        (x_num[:, 0] * x_num[:, 1])[:, None],
+        (x_num[:, 2] ** 2)[:, None],
+    ], axis=-1)
+    score = feat @ jax.random.normal(k_wnum, (feat.shape[1], NUM_CLASSES))
+    for i, card in enumerate(CAT_CARDINALITIES):
+        table = jax.random.normal(jax.random.fold_in(k_cat_eff, i), (card, NUM_CLASSES)) * 1.5
+        score = score + table[x_cat[:, i]]
+
+    y = jnp.argmax(score, axis=-1).astype(jnp.int32)
+    return {"x_num": x_num, "x_cat": x_cat, "y": y}
+```
+
+## The model in NNX
+
+The module holds **one `nnx.Embed` per categorical column**. Because it is a
+*list of submodules*, it must be wrapped in `nnx.List` so NNX registers the
+tables as state — a bare Python list crashes on Flax 0.12.
+
+```python
+from flax import nnx
+
+class TabularDNN(nnx.Module):
+    def __init__(self, num_numeric, cat_cardinalities, embed_dims,
+                 hidden, out_features, *, rngs: nnx.Rngs):
+        # one embedding table per categorical column (MUST be nnx.List)
+        self.embeddings = nnx.List([
+            nnx.Embed(num_embeddings=card, features=dim, rngs=rngs)
+            for card, dim in zip(cat_cardinalities, embed_dims)
+        ])
+        concat_dim = num_numeric + sum(embed_dims)
+        self.fc1 = nnx.Linear(concat_dim, hidden, rngs=rngs)
+        self.fc2 = nnx.Linear(hidden, hidden, rngs=rngs)
+        self.dropout = nnx.Dropout(rate=0.1, rngs=rngs)
+        self.head = nnx.Linear(hidden, out_features, rngs=rngs)
+
+    def __call__(self, x_num, x_cat, train: bool = False):
+        # x_num: (B, num_numeric) float, x_cat: (B, n_cat) int
+        embeds = [emb(x_cat[:, i]) for i, emb in enumerate(self.embeddings)]
+        h = jnp.concatenate([x_num, *embeds], axis=-1)
+        h = nnx.relu(self.fc1(h))
+        h = self.dropout(h, deterministic=not train)
+        h = nnx.relu(self.fc2(h))
+        return self.head(h)          # (B, out_features)
+```
+
+The **classification vs. regression** switch lives entirely in `out_features`:
+
+```python
+def create_model(rngs, *, hidden=64, task="classification"):
+    out_features = 1 if task == "regression" else NUM_CLASSES
+    return TabularDNN(
+        num_numeric=NUM_NUMERIC,
+        cat_cardinalities=CAT_CARDINALITIES,
+        embed_dims=embedding_dims(CAT_CARDINALITIES),
+        hidden=hidden,
+        out_features=out_features,
+        rngs=rngs,
+    )
+```
+
+## The train step
+
+Standard NNX pattern: `nnx.value_and_grad` with `has_aux=True` to carry the
+metric, then `optimizer.update`. For classification we use softmax cross-entropy
+and report accuracy.
+
+```python
+import optax
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["x_num"], batch["x_cat"], train=True)
+        loss = optax.softmax_cross_entropy_with_integer_labels(logits, batch["y"]).mean()
+        acc = jnp.mean(logits.argmax(-1) == batch["y"])
+        return loss, acc
+
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+
+model = create_model(nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+The **regression variant** swaps only the head width, the loss, and squeezes the
+scalar output:
+
+```python
+@nnx.jit
+def train_step_regression(model, optimizer, batch):
+    def loss_fn(model):
+        preds = model(batch["x_num"], batch["x_cat"], train=True)[:, 0]  # (B,)
+        loss = jnp.mean((preds - batch["y"]) ** 2)                       # MSE
+        return loss, loss
+    (loss, _), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, loss
+```
+
+## Results / What to expect
+
+Mini-batch training over 2,000 synthetic rows runs in a few seconds on CPU.
+Cross-entropy falls steadily and accuracy climbs from the ~33% three-class
+baseline into the low 0.80s on the full dataset (individual batches often hit
+higher):
+
+```console
+$ python scientific/tabular_dnn.py
+Tabular DNN (classification) | 2000 rows | 4 numeric + 3 categorical columns (cardinalities (5, 8, 3), embeds (2, 4, 2))
+
+epoch  0 | loss 0.9649 | batch acc 0.535
+epoch  4 | loss 0.7292 | batch acc 0.699
+epoch  8 | loss 0.6128 | batch acc 0.742
+epoch 12 | loss 0.5966 | batch acc 0.770
+epoch 14 | loss 0.5344 | batch acc 0.805
+
+Final full-dataset accuracy: 0.818
+```
+
+On a small fixed batch trained harder (higher learning rate, 40 steps) the model
+essentially memorizes the mapping — loss $1.26 \to 0.08$ and accuracy
+$0.19 \to 0.98$ — confirming the embeddings carry real signal. The regression
+head on the same features drives MSE down by ~20x over the same 40 steps:
+
+```console
+reg mse:  104.42 -> 5.22
+```
+
+## Common pitfalls
+
+**Feeding raw category integers as numeric features.**
+
+❌ Treats `city = 3` as three-times `city = 1`, inventing a false ordering.
+```python
+h = jnp.concatenate([x_num, x_cat.astype(jnp.float32)], axis=-1)
+```
+✅ Look each code up in a learnable embedding table.
+```python
+embeds = [emb(x_cat[:, i]) for i, emb in enumerate(self.embeddings)]
+h = jnp.concatenate([x_num, *embeds], axis=-1)
+```
+
+**Storing the per-column embeddings in a plain Python list.**
+
+❌ A bare list of submodules is not registered as state and crashes on Flax 0.12.
+```python
+self.embeddings = [nnx.Embed(c, d, rngs=rngs) for c, d in ...]
+```
+✅ Wrap submodule collections in `nnx.List`.
+```python
+self.embeddings = nnx.List([nnx.Embed(c, d, rngs=rngs) for c, d in ...])
+```
+
+**One shared embedding table for all columns.**
+
+❌ Column 0's category `2` and column 2's category `2` are unrelated; sharing a
+table forces them to collide.
+```python
+self.embed = nnx.Embed(max_cardinality, dim, rngs=rngs)   # one table, wrong ids
+```
+✅ Give each column its own table sized to its own cardinality.
+```python
+self.embeddings = nnx.List([nnx.Embed(card, dim, rngs=rngs)
+                            for card, dim in zip(cards, dims)])
+```
+
+**Off-by-one on `num_embeddings`.**
+
+❌ Sizing the table to the max id, not the count, indexes out of bounds for the
+top category.
+```python
+nnx.Embed(num_embeddings=x_cat[:, i].max(), features=dim, rngs=rngs)
+```
+✅ Size it to the cardinality (max id + 1).
+```python
+nnx.Embed(num_embeddings=int(x_cat[:, i].max()) + 1, features=dim, rngs=rngs)
+```
+
+**Comparing a `(B, 1)` regression output against a `(B,)` target.**
+
+❌ Broadcasting turns the MSE into a `(B, B)` matrix and silently trains on garbage.
+```python
+loss = jnp.mean((model(x_num, x_cat) - y) ** 2)   # (B,1) vs (B,) -> (B,B)
+```
+✅ Squeeze the head to `(B,)` first.
+```python
+loss = jnp.mean((model(x_num, x_cat)[:, 0] - y) ** 2)
+```
+
+## Next steps
+
+- [Mixture of Experts](/applications/scientific/mixture-of-experts) — route each
+  row to specialized sub-networks, a natural next step for heterogeneous tables.
+- [Graph Neural Networks (GCN)](/applications/scientific/graph-neural-networks) —
+  when rows are not independent but connected in a relational structure.
+
+## Complete Example
+
+[`examples/scientific/tabular_dnn.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/scientific/tabular_dnn.py)
+— the full, runnable tabular DNN with synthetic mixed-type data, per-column
+embeddings, and both the classification and regression training loops.
+
+## References
+
+- Guo & Berkhahn (2016), *Entity Embeddings of Categorical Variables* — [arXiv:1604.06737](https://arxiv.org/abs/1604.06737)
+- Gorishniy et al. (2021), *Revisiting Deep Learning Models for Tabular Data* — [arXiv:2106.11959](https://arxiv.org/abs/2106.11959)
+- Arik & Pfister (2019), *TabNet: Attentive Interpretable Tabular Learning* — [arXiv:1908.07442](https://arxiv.org/abs/1908.07442)
+- Huang et al. (2020), *TabTransformer: Tabular Data Modeling Using Contextual Embeddings* — [arXiv:2012.06678](https://arxiv.org/abs/2012.06678)

--- a/website/docs/applications/sequence/index.md
+++ b/website/docs/applications/sequence/index.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 0
+title: Sequence Models & Time Series in Flax NNX
+description: Build recurrent networks (RNN, LSTM, GRU) and sequence models in Flax NNX using the nnx.RNN API family and nnx.scan.
+keywords: [rnn, lstm, gru, sequence model, time series, flax nnx, jax, nnx.RNN, nnx.scan, recurrent]
+---
+
+# Sequence Models & Time Series
+
+Not all data lives on a grid. Text, audio, and time series are **ordered
+sequences** where what came before shapes what comes next. This track covers the
+recurrent model family — the pre-transformer workhorses that are still the right
+tool for many small sequence tasks.
+
+## What you'll build
+
+- **[Recurrent Networks (RNN / LSTM / GRU)](/applications/sequence/recurrent-networks)** —
+  the carry-state primitive and the full `nnx.RNN`, `nnx.LSTMCell`, `nnx.GRUCell`,
+  and `nnx.Bidirectional` API family, plus the manual `nnx.scan` view under the hood.
+
+More guides in this track (seq2seq with attention, time-series forecasting, and
+learned word embeddings) are on the way.
+
+## Prerequisites
+
+You should have built [your first model](/basics/fundamentals/your-first-model)
+and understand [Flax NNX state](/basics/fundamentals/understanding-state) —
+recurrence is all about threading state (the *carry*) through time.
+
+## Next steps
+
+- Build [Recurrent Networks](/applications/sequence/recurrent-networks).
+- Compare with the attention-based [Transformer](/basics/text/simple-transformer).

--- a/website/docs/applications/sequence/index.md
+++ b/website/docs/applications/sequence/index.md
@@ -17,9 +17,12 @@ tool for many small sequence tasks.
 - **[Recurrent Networks (RNN / LSTM / GRU)](/applications/sequence/recurrent-networks)** —
   the carry-state primitive and the full `nnx.RNN`, `nnx.LSTMCell`, `nnx.GRUCell`,
   and `nnx.Bidirectional` API family, plus the manual `nnx.scan` view under the hood.
-
-More guides in this track (seq2seq with attention, time-series forecasting, and
-learned word embeddings) are on the way.
+- **[Sequence-to-Sequence with Attention](/applications/sequence/seq2seq)** — an
+  encoder-decoder with cross-attention that maps one sequence to another.
+- **[Time-Series Forecasting](/applications/sequence/time-series)** — predict future
+  values from a sliding window with an LSTM.
+- **[Word Embeddings (word2vec)](/applications/sequence/word2vec)** — learn
+  representations of tokens with skip-gram and negative sampling.
 
 ## Prerequisites
 

--- a/website/docs/applications/sequence/recurrent-networks.md
+++ b/website/docs/applications/sequence/recurrent-networks.md
@@ -1,0 +1,267 @@
+---
+sidebar_position: 1
+title: Recurrent Networks - RNN, LSTM & GRU in Flax NNX
+description: "Build RNN, LSTM, GRU and bidirectional recurrent networks in Flax NNX with the nnx.RNN API, master the LSTM gate math, and train on a parity task."
+keywords: [recurrent neural network, LSTM, GRU, RNN, Flax NNX, JAX, nnx.RNN, bidirectional RNN, sequence modeling, vanishing gradient, nnx.scan, carry]
+image: img/docusaurus-social-card.jpg
+---
+
+# Recurrent Networks: RNN, LSTM & GRU
+
+**Teach a network to remember.** Recurrent networks process a sequence one step at a time, carrying a hidden state forward so that earlier tokens can influence later predictions. This guide builds vanilla RNN, LSTM, GRU, and bidirectional classifiers in Flax NNX, derives the LSTM gate equations, and trains them on a parity task that *cannot* be solved without integrating information across every time step.
+
+:::note Prerequisites
+Comfortable defining modules and running a training loop? You should have read [your first model](/basics/fundamentals/your-first-model), [understanding state](/basics/fundamentals/understanding-state), and [simple training](/basics/workflows/simple-training). Recurrent layers are stateful, so the state page is especially relevant.
+:::
+
+:::tip What you'll learn
+- How `nnx.RNN` turns any recurrent **cell** into a layer that scans over time
+- The **LSTM gate equations** — forget, input, output — and the two-part carry `(h, c)`
+- Why **gating fixes vanishing gradients** where a vanilla RNN fails
+- How to swap in `nnx.GRUCell`, `nnx.SimpleCell`, and `nnx.Bidirectional`
+- What `nnx.RNN` does under the hood, written out as an explicit `nnx.scan` with **carry threading**
+:::
+
+:::info Example Code
+See the full implementation: [`examples/sequence/rnn_cells.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/rnn_cells.py)
+:::
+
+## Why Recurrence?
+
+An MLP or CNN sees a fixed-size input all at once. Sequences — text, audio, sensor streams, time series — are different: they have variable length and their *order* carries meaning. A recurrent network processes the sequence step by step, maintaining a **hidden state** $h_t$ that summarizes everything seen so far:
+
+$$
+h_t = f(x_t, h_{t-1})
+$$
+
+The same cell $f$ is applied at every step, sharing parameters across time. That single recurrence is the whole idea — but making it *learn* long-range dependencies is where LSTMs and GRUs come in.
+
+### The task: parity
+
+Our benchmark is deliberately unforgiving. Given a sequence of integer tokens, predict the **parity** of their sum:
+
+$$
+y = \left(\sum_{t=1}^{T} x_t\right) \bmod 2 \in \{0, 1\}
+$$
+
+Parity is a perfect recurrent stress test: flipping a *single* token flips the label, so the network must carry an exact running state across the whole sequence. There is no shortcut — a model that ignores any time step cannot beat 50%.
+
+## The vanishing gradient problem
+
+A vanilla RNN computes $h_t = \tanh(W x_t + U h_{t-1} + b)$. Backpropagating the loss at step $T$ to step $t$ multiplies many Jacobians together:
+
+$$
+\frac{\partial h_T}{\partial h_t} = \prod_{k=t+1}^{T} \frac{\partial h_k}{\partial h_{k-1}}
+= \prod_{k=t+1}^{T} \operatorname{diag}\big(\tanh'(\cdot)\big)\, U^\top
+$$
+
+Because $\tanh' \le 1$ and $U$ typically has spectral radius below 1, this product shrinks **exponentially** with $T - t$. Early-step gradients vanish, and the network never learns long-range dependencies. (When the norm is instead above 1, the same product *explodes*.)
+
+## The LSTM: gating to the rescue
+
+The Long Short-Term Memory cell adds a second piece of state — the **cell state** $c_t$ — and three sigmoid **gates** that decide what to keep, write, and read. The full carry is the pair $(h_t, c_t)$.
+
+$$
+\begin{aligned}
+f_t &= \sigma(W_f x_t + U_f h_{t-1} + b_f) && \text{forget gate} \\
+i_t &= \sigma(W_i x_t + U_i h_{t-1} + b_i) && \text{input gate} \\
+o_t &= \sigma(W_o x_t + U_o h_{t-1} + b_o) && \text{output gate} \\
+\tilde{c}_t &= \tanh(W_c x_t + U_c h_{t-1} + b_c) && \text{candidate} \\
+c_t &= f_t \odot c_{t-1} + i_t \odot \tilde{c}_t && \text{cell update} \\
+h_t &= o_t \odot \tanh(c_t) && \text{hidden output}
+\end{aligned}
+$$
+
+Here $\sigma$ is the logistic sigmoid, $\odot$ is elementwise multiplication, and each gate is a vector in $(0, 1)$.
+
+**Why this fixes vanishing gradients.** The cell update is *additive*: $c_t = f_t \odot c_{t-1} + \dots$. The gradient flowing back through the cell state is
+
+$$
+\frac{\partial c_t}{\partial c_{t-1}} = \operatorname{diag}(f_t)
+$$
+
+When the forget gate stays near 1, this is close to the identity, so gradients travel across many steps **without shrinking** — a "constant error carousel." The network *learns* how long to remember by controlling $f_t$, instead of being forced to forget by the geometry of repeated matrix products.
+
+## Building the model in Flax NNX
+
+Flax NNX separates the **cell** (one step of recurrence) from the **layer** (the scan over time). `nnx.RNN` wraps any cell and applies it across the time axis of a `(B, T, features)` input, returning per-step outputs `(B, T, hidden)`. We embed integer tokens, run the RNN, and classify from the *last* step.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+
+class LSTMClassifier(nnx.Module):
+    def __init__(self, vocab, embed, hidden, n_classes, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.LSTMCell(embed, hidden, rngs=rngs))
+        self.head = nnx.Linear(hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)      # (B, T)        -> (B, T, embed)
+        h = self.rnn(h)             # (B, T, embed) -> (B, T, hidden)
+        return self.head(h[:, -1])  # last step     -> (B, n_classes)
+```
+
+### Swapping the cell: GRU and vanilla RNN
+
+The cell is the only thing that changes. A **GRU** (`nnx.GRUCell`) merges the forget and input gates into a single update gate and carries just `h` — fewer parameters, often comparable accuracy. A **vanilla RNN** (`nnx.SimpleCell`) has no gates at all and is our vanishing-gradient baseline.
+
+```python
+class GRUClassifier(nnx.Module):
+    def __init__(self, vocab, embed, hidden, n_classes, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.GRUCell(embed, hidden, rngs=rngs))   # gated, single carry h
+        self.head = nnx.Linear(hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)
+        h = self.rnn(h)
+        return self.head(h[:, -1])
+
+
+class VanillaRNNClassifier(nnx.Module):
+    def __init__(self, vocab, embed, hidden, n_classes, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.SimpleCell(embed, hidden, rngs=rngs))  # no gates
+        self.head = nnx.Linear(hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)
+        h = self.rnn(h)
+        return self.head(h[:, -1])
+```
+
+### Bidirectional: reading both ways
+
+For tasks where the *whole* sequence is available (classification, tagging), a **bidirectional** RNN runs one cell forward and another backward, then concatenates their outputs. Each position now sees both past and future context. `nnx.Bidirectional` handles the reversal, scan, and merge; the classifier head just needs `2 * hidden` inputs.
+
+```python
+class BiLSTMClassifier(nnx.Module):
+    def __init__(self, vocab, embed, hidden, n_classes, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        forward = nnx.RNN(nnx.LSTMCell(embed, hidden, rngs=rngs))
+        backward = nnx.RNN(nnx.LSTMCell(embed, hidden, rngs=rngs))
+        self.birnn = nnx.Bidirectional(forward, backward)          # concatenates fwd ++ bwd
+        self.head = nnx.Linear(2 * hidden, n_classes, rngs=rngs)
+
+    def __call__(self, tokens):
+        h = self.embed(tokens)      # (B, T, embed)
+        h = self.birnn(h)           # (B, T, 2*hidden)
+        return self.head(h[:, -1])
+```
+
+## Under the hood: carry threading with `nnx.scan`
+
+`nnx.RNN` is a convenience wrapper around a `scan`. Writing that scan by hand is the clearest way to understand **carry threading** — the mechanism that passes the recurrent state from one step to the next.
+
+The pattern: initialize the carry with `cell.initialize_carry`, then decorate a per-step function with `@nnx.scan`. The special `nnx.Carry` marker in `in_axes`/`out_axes` says "this argument is threaded, not sliced"; the integer `1` says "slice/stack this argument along the time axis."
+
+```python
+def manual_lstm_scan(cell: nnx.LSTMCell, sequence):
+    batch = sequence.shape[0]
+    in_features = sequence.shape[-1]
+    carry = cell.initialize_carry((batch, in_features), nnx.Rngs(0))  # (h, c), each (B, hidden)
+
+    @nnx.scan(in_axes=(nnx.Carry, 1), out_axes=(nnx.Carry, 1))
+    def step(carry, x_t):
+        carry, y_t = cell(carry, x_t)   # ((h, c), x_t) -> ((h, c), y_t)
+        return carry, y_t
+
+    carry, outputs = step(carry, sequence)  # carry: final (h, c); outputs: (B, T, hidden)
+    return carry, outputs
+```
+
+This produces bit-for-bit the same per-step outputs as `nnx.RNN(cell)(sequence)` — the wrapper is exactly this scan plus some ergonomics (masking, reversal, time-major handling). For an LSTM the carry is the tuple `(h, c)`; for a GRU or vanilla RNN it is just `h`.
+
+## The training step
+
+Standard NNX training: cross-entropy on the last-step logits, `nnx.value_and_grad` with `has_aux=True` to also return logits for the accuracy metric, and `optimizer.update(model, grads)`.
+
+```python
+from shared.training_utils import compute_accuracy, compute_cross_entropy_loss
+
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["x"])
+        loss = compute_cross_entropy_loss(logits, batch["y"])
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    acc = compute_accuracy(logits, batch["y"])
+    return loss, acc
+```
+
+Build the model and optimizer explicitly, then loop:
+
+```python
+model = LSTMClassifier(vocab=10, embed=32, hidden=64, n_classes=2, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+
+for step in range(30):
+    loss, acc = train_step(model, optimizer, {"x": x_batch, "y": y_batch})
+```
+
+The dataset is generated on the fly — no downloads:
+
+```python
+key = jax.random.key(0)
+x = jax.random.randint(key, (512, 12), 0, 10)   # tokens in [0, 10)
+y = (x.sum(axis=1) % 2).astype(jnp.int32)        # parity label
+```
+
+## Results / What to Expect
+
+Parity is fully learnable by a gated recurrent network. On CPU, the LSTM drives cross-entropy toward zero and hits **100% accuracy** within ~30 steps:
+
+```console
+$ python sequence/rnn_cells.py
+model=lstm samples=512 seq_len=12 epochs=40 batch=128
+epoch  0  loss 0.7112  acc 0.4844
+epoch  4  loss 0.6722  acc 0.5938
+epoch  9  loss 0.5305  acc 0.7422
+epoch 19  loss 0.0337  acc 0.9922
+epoch 39  loss 0.0006  acc 1.0000
+manual scan outputs (4, 12, 64)  carry h (4, 64)  c (4, 64)
+```
+
+Try `MODEL=gru` or `MODEL=bilstm` (both solve it), and `MODEL=rnn` for the vanilla baseline — the `nnx.SimpleCell` struggles as you push `seq_len` higher, exactly the vanishing-gradient behavior the gates were designed to cure. Environment knobs `EPOCHS`, `BATCH`, and `SYNTHETIC` let you scale the run.
+
+## Common Pitfalls
+
+- ❌ Feeding `(B, features)` to `nnx.RNN` and wondering why it errors.
+  ✅ `nnx.RNN` expects a **time axis**: shape `(B, T, features)`. Embed first, then scan.
+
+- ❌ Classifying from `h[:, 0]` or averaging all steps for a task that needs the full sequence.
+  ✅ For parity, use the **last step** `h[:, -1]` (or a bidirectional final state) so the state has seen every token.
+
+- ❌ Building `LSTMCell(embed, hidden)` but wiring the head from `embed`.
+  ✅ The RNN outputs **`hidden`**-dim vectors; the head is `nnx.Linear(hidden, n_classes)` (and `2 * hidden` for bidirectional).
+
+- ❌ Expecting a vanilla `nnx.SimpleCell` to match the LSTM on long sequences.
+  ✅ Gates exist precisely to carry gradients across time; reach for `LSTMCell`/`GRUCell` when dependencies are long.
+
+- ❌ Putting a Python list of cells in a plain attribute to stack RNN layers.
+  ✅ On Flax 0.12 wrap submodule lists in `nnx.List([...])` (and dicts in `nnx.Dict({...})`) so they register as state.
+
+## Next steps
+
+- [Simple Transformer](/basics/text/simple-transformer) — attention replaces recurrence and parallelizes across time.
+- [Graph Neural Networks](/applications/scientific/graph-neural-networks) — message passing generalizes recurrence to arbitrary graphs.
+
+## Complete Example
+
+Full runnable script with all four model variants, the manual scan, and the training loop: [`examples/sequence/rnn_cells.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/rnn_cells.py).
+
+## References
+
+- Hochreiter & Schmidhuber (1997), *Long Short-Term Memory* — [Neural Computation 9(8)](https://doi.org/10.1162/neco.1997.9.8.1735).
+- Cho et al. (2014), *Learning Phrase Representations using RNN Encoder–Decoder* (GRU) — [arXiv:1406.1078](https://arxiv.org/abs/1406.1078).
+- Pascanu, Mikolov & Bengio (2013), *On the Difficulty of Training Recurrent Neural Networks* — [arXiv:1211.5063](https://arxiv.org/abs/1211.5063).
+- Chung et al. (2014), *Empirical Evaluation of Gated Recurrent Neural Networks on Sequence Modeling* — [arXiv:1412.3555](https://arxiv.org/abs/1412.3555).
+- Greff et al. (2015), *LSTM: A Search Space Odyssey* — [arXiv:1503.04069](https://arxiv.org/abs/1503.04069).

--- a/website/docs/applications/sequence/seq2seq.md
+++ b/website/docs/applications/sequence/seq2seq.md
@@ -1,0 +1,231 @@
+---
+sidebar_position: 2
+title: Sequence-to-Sequence with Attention in Flax NNX
+description: "Build an encoder-decoder with cross-attention in Flax NNX, train it on a copy-and-reverse task with teacher forcing, and watch attention align source to target."
+keywords: [seq2seq, sequence to sequence, attention, encoder decoder, cross-attention, Flax NNX, JAX, nnx.MultiHeadAttention, teacher forcing, GRU, Bahdanau attention, machine translation]
+image: img/docusaurus-social-card.jpg
+---
+
+# Sequence-to-Sequence with Attention
+
+**Map one sequence to another.** An encoder reads the source, a decoder writes the target, and cross-attention lets every output step look back at the whole input. This guide builds an encoder-decoder in Flax NNX, trains it with teacher forcing on a copy-and-reverse task, and shows how attention learns the source-to-target alignment.
+
+:::note Prerequisites
+This guide assumes you have met recurrent cells and attention already. Read [recurrent networks](/applications/sequence/recurrent-networks) for the GRU encoder/decoder, and [simple transformer](/basics/text/simple-transformer) for how multi-head attention works.
+:::
+
+:::tip What you'll learn
+- The **encoder-decoder** architecture: compress a source sequence into per-step states, then generate a target from them
+- How **cross-attention** forms a context vector $c_t = \sum_i \alpha_{t,i} h_i$ over the encoder states with `nnx.MultiHeadAttention`
+- **Teacher forcing** — feeding the ground-truth previous token so the decoder trains in parallel
+- Why this is a **conditional source → target** model, unlike a decoder-only GPT
+- How to score sequence output with **per-token accuracy** and a token-level cross-entropy
+:::
+
+:::info Example Code
+See the full implementation: [`examples/sequence/seq2seq_attention.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/seq2seq_attention.py)
+:::
+
+## Why Encoder-Decoder?
+
+A recurrent classifier collapses a whole sequence into a single label. But many problems map a sequence to *another sequence* of possibly different content and length: translation, summarization, speech-to-text. The **encoder-decoder** (seq2seq) design splits the job in two:
+
+- an **encoder** reads the source $x_{1:T}$ and produces a stack of hidden states $h_{1:T}$;
+- a **decoder** generates the target $y_{1:U}$ one token at a time, conditioned on those states and on what it has already emitted.
+
+The original seq2seq crammed the entire source into the encoder's *final* state — a fixed-size bottleneck that forgets long inputs. **Attention** removes the bottleneck: at each output step the decoder builds a fresh, weighted read over *all* encoder states.
+
+### The task: copy-and-reverse
+
+Our benchmark maps a source sequence to its reverse:
+
+$$
+\text{src} = [a, b, c, d] \quad\longrightarrow\quad \text{tgt} = [d, c, b, a]
+$$
+
+It is a clean attention probe: to emit output position $t$ correctly, the decoder must attend to source position $T-1-t$ and copy that token. There is no fixed offset the recurrence can memorize — the alignment reverses across the sequence — so a model that solves it has genuinely learned to *point* with attention. Everything is generated in memory; there is nothing to download.
+
+## Attention: a differentiable lookup
+
+At decoder step $t$ we have a query $q_t$ (from the decoder state) and, for every source position $i$, a key $k_i$ and value $v_i$ (from the encoder states). Attention scores each source position, normalizes with a softmax, and returns the value average:
+
+$$
+e_{t,i} = \frac{q_t \cdot k_i}{\sqrt{d}}, \qquad
+\alpha_{t,i} = \frac{\exp(e_{t,i})}{\sum_{j} \exp(e_{t,j})}, \qquad
+c_t = \sum_{i} \alpha_{t,i}\, v_i
+$$
+
+The weights $\alpha_{t,\cdot}$ form a soft, differentiable alignment: a distribution over source positions that says *where to look*. For the reverse task, a well-trained model puts almost all of $\alpha_{t,\cdot}$ on position $T-1-t$. **Multi-head** attention runs $H$ of these in parallel over projected subspaces and concatenates the results, so different heads can track different alignment cues.
+
+Because keys/values come from the encoder and queries come from the decoder, this is **cross-attention** — distinct from the **self-attention** a GPT applies within a single stream.
+
+## Building the model in Flax NNX
+
+### Encoder
+
+The encoder is exactly the recurrent stack from the [recurrent networks](/applications/sequence/recurrent-networks) guide: embed the tokens, scan a GRU across time with `nnx.RNN`, and keep *all* per-step states (not just the last), because the decoder attends over the whole stack.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+
+class Encoder(nnx.Module):
+    def __init__(self, vocab, embed, hidden, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(vocab, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.GRUCell(embed, hidden, rngs=rngs))
+
+    def __call__(self, src):
+        h = self.embed(src)   # (B, T)        -> (B, T, embed)
+        return self.rnn(h)    # (B, T, embed) -> (B, T, hidden)  encoder states
+```
+
+### Decoder with cross-attention
+
+The decoder embeds the (teacher-forced) previous tokens, runs its own GRU to get a per-step decoder state, then uses `nnx.MultiHeadAttention` as **cross-attention**: the *query* is the decoder state, the *keys and values* are the encoder states. The context vector is concatenated with the decoder state and projected to the vocabulary.
+
+```python
+class Decoder(nnx.Module):
+    def __init__(self, vocab, embed, hidden, num_heads, *, rngs: nnx.Rngs):
+        # vocab + 1: the extra id is the <bos> start token fed at step 0.
+        self.embed = nnx.Embed(vocab + 1, embed, rngs=rngs)
+        self.rnn = nnx.RNN(nnx.GRUCell(embed, hidden, rngs=rngs))
+        self.cross_attn = nnx.MultiHeadAttention(
+            num_heads=num_heads,
+            in_features=hidden,      # query dim (decoder state)
+            in_kv_features=hidden,   # key/value dim (encoder states)
+            qkv_features=hidden,
+            decode=False,
+            rngs=rngs,
+        )
+        self.out = nnx.Linear(2 * hidden, vocab, rngs=rngs)
+
+    def __call__(self, dec_in, enc_states):
+        d = self.embed(dec_in)          # (B, T)        -> (B, T, embed)
+        d = self.rnn(d)                 # (B, T, embed) -> (B, T, hidden)  decoder states
+        # Cross-attention: query = decoder states, key/value = encoder states.
+        ctx = self.cross_attn(d, enc_states, enc_states)   # (B, T, hidden)  context c_t
+        combined = jnp.concatenate([d, ctx], axis=-1)      # (B, T, 2*hidden)
+        return self.out(combined)                          # (B, T, vocab)   logits
+```
+
+Passing three arguments to `nnx.MultiHeadAttention(inputs_q, inputs_k, inputs_v)` is what makes it cross-attention: `inputs_q` comes from the decoder while `inputs_k` and `inputs_v` come from the encoder. (Calling it with a single argument would be ordinary self-attention.)
+
+### Wiring it together
+
+```python
+class Seq2SeqAttention(nnx.Module):
+    def __init__(self, vocab, embed, hidden, num_heads, *, rngs: nnx.Rngs):
+        self.encoder = Encoder(vocab, embed, hidden, rngs=rngs)
+        self.decoder = Decoder(vocab, embed, hidden, num_heads, rngs=rngs)
+
+    def __call__(self, src, dec_in):
+        enc_states = self.encoder(src)              # (B, T, hidden)
+        return self.decoder(dec_in, enc_states)     # (B, T_out, vocab)
+```
+
+## Teacher forcing and the data
+
+During training we feed the decoder the **ground-truth** previous target token rather than its own prediction — this is *teacher forcing*. It lets the decoder process all steps in one parallel pass and gives a stable learning signal early on. The decoder input is the target shifted right by one, with a special `<bos>` (begin-of-sequence) id in the first slot:
+
+$$
+\text{dec\_in} = [\,\langle\text{bos}\rangle,\; y_1,\; y_2,\; \dots,\; y_{U-1}\,]
+$$
+
+```python
+def make_dataset(synthetic=True, *, n=1024, seq_len=8, vocab=12, seed=0):
+    key = jax.random.key(seed)
+    src = jax.random.randint(key, (n, seq_len), 0, vocab).astype(jnp.int32)
+    tgt = src[:, ::-1]                                    # reversed sequence
+    bos = jnp.full((n, 1), vocab, dtype=jnp.int32)        # start-of-sequence id
+    dec_in = jnp.concatenate([bos, tgt[:, :-1]], axis=1)  # shift-right teacher forcing
+    return {"src": src, "dec_in": dec_in, "tgt": tgt}
+```
+
+## The training step
+
+The output is a full sequence of logits `(B, T, vocab)`, so we flatten to `(B*T, vocab)` and score every token position with cross-entropy. Per-token accuracy is the fraction of positions predicted correctly.
+
+```python
+from shared.training_utils import compute_accuracy, compute_cross_entropy_loss
+
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["src"], batch["dec_in"])   # (B, T, vocab)
+        B, T, V = logits.shape
+        flat_logits = logits.reshape(B * T, V)
+        flat_tgt = batch["tgt"].reshape(B * T)
+        loss = compute_cross_entropy_loss(flat_logits, flat_tgt)
+        acc = compute_accuracy(flat_logits, flat_tgt)    # per-token accuracy
+        return loss, acc
+
+    (loss, acc), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, acc
+```
+
+Build the model and optimizer explicitly, then loop:
+
+```python
+model = Seq2SeqAttention(vocab=12, embed=32, hidden=64, num_heads=4, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(3e-3), wrt=nnx.Param)
+
+for step in range(...):
+    loss, acc = train_step(model, optimizer, batch)
+```
+
+## Results / What to Expect
+
+The reverse task is fully learnable with attention. On CPU, per-token accuracy climbs past 90% within a dozen epochs and reaches **100%** as the cross-attention locks onto the reversed alignment:
+
+```console
+$ python sequence/seq2seq_attention.py
+seq2seq+attention  samples=1024 seq_len=8 vocab=12 epochs=30 batch=128
+epoch  0  loss 2.3614  token_acc 0.1953
+epoch  5  loss 1.6474  token_acc 0.4102
+epoch  8  loss 0.7278  token_acc 0.7129
+epoch 12  loss 0.1573  token_acc 0.9648
+epoch 17  loss 0.0294  token_acc 0.9980
+epoch 20  loss 0.0144  token_acc 1.0000
+epoch 29  loss 0.0046  token_acc 1.0000
+```
+
+Environment knobs `EPOCHS`, `BATCH`, and `SYNTHETIC` let you scale the run; `SYNTHETIC=0` generates a larger, longer (harder) dataset.
+
+## Common Pitfalls
+
+- ❌ Calling `nnx.MultiHeadAttention(x)` with one argument and expecting cross-attention.
+  ✅ Cross-attention needs three inputs: `attn(query, key, value)` = `attn(decoder_states, encoder_states, encoder_states)`.
+
+- ❌ Attending over only the encoder's **last** state (the fixed-size bottleneck).
+  ✅ Keep *all* per-step states from `nnx.RNN` — attention reads the full `(B, T, hidden)` stack.
+
+- ❌ Feeding the target itself as the decoder input, leaking the answer at each step.
+  ✅ Shift right by one and prepend `<bos>`: `dec_in = [<bos>, y_1, ..., y_{U-1}]`.
+
+- ❌ Sizing the output head from `hidden` when you concatenate the context.
+  ✅ The decoder state and context are concatenated, so the head is `nnx.Linear(2 * hidden, vocab)`.
+
+- ❌ Setting `qkv_features` so it is not divisible by `num_heads`.
+  ✅ Multi-head attention splits `qkv_features` across heads; keep `qkv_features % num_heads == 0` (here `64 % 4 == 0`).
+
+## Next steps
+
+- [Time series](/applications/sequence/time-series) — apply sequence models to forecasting continuous signals.
+- [GPT](/architectures/gpt) — drop the encoder and use masked *self*-attention for a decoder-only generative model.
+
+## Complete Example
+
+Full runnable script with the encoder, cross-attention decoder, teacher-forcing data, and the training loop: [`examples/sequence/seq2seq_attention.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/seq2seq_attention.py).
+
+## References
+
+- Sutskever, Vinyals & Le (2014), *Sequence to Sequence Learning with Neural Networks* — [arXiv:1409.3215](https://arxiv.org/abs/1409.3215).
+- Bahdanau, Cho & Bengio (2014), *Neural Machine Translation by Jointly Learning to Align and Translate* — [arXiv:1409.0473](https://arxiv.org/abs/1409.0473).
+- Cho et al. (2014), *Learning Phrase Representations using RNN Encoder–Decoder* (GRU) — [arXiv:1406.1078](https://arxiv.org/abs/1406.1078).
+- Luong, Pham & Manning (2015), *Effective Approaches to Attention-based Neural Machine Translation* — [arXiv:1508.04025](https://arxiv.org/abs/1508.04025).
+- Vaswani et al. (2017), *Attention Is All You Need* — [arXiv:1706.03762](https://arxiv.org/abs/1706.03762).

--- a/website/docs/applications/sequence/time-series.md
+++ b/website/docs/applications/sequence/time-series.md
@@ -1,0 +1,198 @@
+---
+sidebar_position: 3
+title: LSTM Time-Series Forecasting in Flax NNX
+description: "Forecast a synthetic time series with an LSTM in Flax NNX: sliding windows, multi-step regression with nnx.RNN, an MSE loss, and a held-out evaluation."
+keywords: [time series forecasting, LSTM, Flax NNX, JAX, nnx.RNN, sliding window, multi-step forecast, sequence regression, MSE loss, sinusoid, LSTMCell]
+image: img/docusaurus-social-card.jpg
+---
+
+# LSTM Time-Series Forecasting
+
+**Read the recent past, predict the near future.** This guide slices a signal into sliding windows and trains an LSTM to map the last `L` observations to the next `H` values — standard supervised, multi-step forecasting in Flax NNX, all on synthetic data that needs no download.
+
+:::note Prerequisites
+This builds directly on recurrent layers. Read [recurrent networks](/applications/sequence/recurrent-networks) for the `nnx.RNN` / `nnx.LSTMCell` API and the LSTM gate math, and [simple training](/basics/workflows/simple-training) for the NNX training loop.
+:::
+
+:::tip What you'll learn
+- How to turn a raw 1-D series into `(window -> horizon)` supervised pairs with **sliding windows**
+- How to build a **multi-step forecaster**: `nnx.RNN(nnx.LSTMCell)` encoder + a `nnx.Linear` head to `H` outputs
+- Why forecasting uses an **MSE regression loss** instead of cross-entropy
+- How to split *in time* and **standardize with train statistics only** so the future never leaks
+- How to read the result: `test_mse` falling and the forecast tracking the held-out continuation
+:::
+
+:::info Example Code
+See the full implementation: [`examples/sequence/time_series.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/time_series.py)
+:::
+
+## From a series to a supervised problem
+
+A time series is a single long vector $s_1, s_2, \dots, s_T$. To train a model with mini-batches we reframe forecasting as ordinary supervised learning using a **sliding window**. Pick an input length $L$ (the *lookback*) and a forecast length $H$ (the *horizon*). Every position $i$ yields one training pair:
+
+$$
+\underbrace{(s_i, s_{i+1}, \dots, s_{i+L-1})}_{\text{input window } x^{(i)}}
+\;\longrightarrow\;
+\underbrace{(s_{i+L}, \dots, s_{i+L+H-1})}_{\text{target } y^{(i)}}
+$$
+
+Sliding the window by one step across the series produces $N = T - L - H + 1$ overlapping examples. The model learns a single function $f_\theta: \mathbb{R}^{L} \to \mathbb{R}^{H}$ that it applies at every position — the same weight-sharing idea that makes recurrence work, now lifted to the dataset level.
+
+### This is *not* meta-learning
+
+If you have seen the MAML sine-wave example, note the difference: there each sine wave is a **separate task** and the model adapts from a handful of shots. Here there is **one** series and **one** task; we simply cut it into many windows and do standard batched gradient descent. No inner loop, no fast weights.
+
+## The data: sum of sinusoids
+
+Real univariate series — energy load, temperature, request rates — are dominated by a few periodic components riding on noise. We synthesize exactly that, so the example is fully offline and reproducible:
+
+$$
+s_t = \sin\!\left(\tfrac{2\pi t}{24}\right)
+    + 0.5\,\sin\!\left(\tfrac{2\pi t}{168}\right)
+    + 0.3\,\sin\!\left(\tfrac{2\pi t}{7}\right)
+    + 0.1\,\varepsilon_t,\qquad \varepsilon_t \sim \mathcal{N}(0,1)
+$$
+
+The periodic terms make the future *predictable* from the past; the noise term stops the LSTM from memorizing and forces it to learn the underlying structure.
+
+```python
+import jax
+import jax.numpy as jnp
+
+
+def make_series(length, *, seed=0):
+    t = jnp.arange(length, dtype=jnp.float32)
+    series = (
+        1.0 * jnp.sin(2 * jnp.pi * t / 24.0)     # daily-like cycle
+        + 0.5 * jnp.sin(2 * jnp.pi * t / 168.0)  # weekly-like cycle
+        + 0.3 * jnp.sin(2 * jnp.pi * t / 7.0)    # short ripple
+    )
+    noise = 0.1 * jax.random.normal(jax.random.key(seed), (length,))
+    return series + noise
+```
+
+We `vmap` a `dynamic_slice` to cut every window in one vectorized shot, adding a trailing feature axis so the shape is `(N, L, 1)` — exactly what `nnx.RNN` expects:
+
+```python
+def make_windows(series, window, horizon):
+    n = series.shape[0] - window - horizon + 1
+    starts = jnp.arange(n)
+    x = jax.vmap(lambda s: jax.lax.dynamic_slice(series, (s,), (window,)))(starts)
+    y = jax.vmap(lambda s: jax.lax.dynamic_slice(series, (s + window,), (horizon,)))(starts)
+    return x[..., None], y   # (N, window, 1), (N, horizon)
+```
+
+**Split in time, then standardize with train stats only.** We cut the series into a past (train) and a future (test) *before* windowing, compute the mean and std on the training region alone, and apply them everywhere. Standardizing with future statistics would leak information the model could never have at inference time.
+
+```python
+split = int(0.8 * length)
+mean = series[:split].mean()
+std = series[:split].std() + 1e-6
+series = (series - mean) / std
+```
+
+## The model in Flax NNX
+
+The forecaster is a two-line module: an LSTM encoder over the window, then a linear projection from the final hidden state to all `H` future values at once (a *direct* multi-step forecast).
+
+```python
+from flax import nnx
+
+
+class LSTMForecaster(nnx.Module):
+    def __init__(self, in_features, hidden, horizon, *, rngs: nnx.Rngs):
+        self.rnn = nnx.RNN(nnx.LSTMCell(in_features, hidden, rngs=rngs))
+        self.head = nnx.Linear(hidden, horizon, rngs=rngs)
+
+    def __call__(self, x):
+        h = self.rnn(x)             # (B, L, in_features) -> (B, L, hidden)
+        return self.head(h[:, -1])  # last step           -> (B, horizon)
+```
+
+`nnx.RNN` scans the `nnx.LSTMCell` across the time axis and returns every step's hidden state, `(B, L, hidden)`. We keep the **last** state `h[:, -1]` — it has integrated the entire lookback — and the head maps it to the `H`-step forecast. For a univariate series `in_features = 1`; for multivariate input you would simply stack channels on the last axis.
+
+## The training step
+
+Forecasting is regression, so the loss is **mean squared error**, not cross-entropy. Everything else is the standard NNX pattern: `nnx.value_and_grad` with `has_aux=True` to also return predictions, then `optimizer.update(model, grads)`.
+
+```python
+import optax
+from shared.training_utils import compute_mse_loss
+
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        preds = model(batch["x"])            # (B, horizon)
+        loss = compute_mse_loss(preds, batch["y"])
+        return loss, preds
+
+    (loss, preds), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, preds
+```
+
+Build the model and optimizer explicitly, then loop over shuffled windows:
+
+```python
+model = LSTMForecaster(in_features=1, hidden=64, horizon=12, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(5e-3), wrt=nnx.Param)
+
+for epoch in range(40):
+    perm = jax.random.permutation(jax.random.key(epoch), n)
+    for i in range(0, n - batch_size + 1, batch_size):
+        idx = perm[i:i + batch_size]
+        loss, _ = train_step(model, optimizer, {"x": x_tr[idx], "y": y_tr[idx]})
+```
+
+## Results / What to Expect
+
+With a lookback of 48 and a horizon of 12, both the training and held-out MSE fall steadily as the LSTM locks onto the periodic structure. Because the test windows are a genuine continuation of the series, the falling `test_mse` is real generalization, not memorization:
+
+```console
+$ python sequence/time_series.py
+train_windows=350 test_windows=92 window=48 horizon=12 epochs=40 batch=64
+epoch  0  train_mse 0.7987  test_mse 0.7126
+epoch  5  train_mse 0.2200  test_mse 0.2149
+epoch 10  train_mse 0.1280  test_mse 0.1634
+epoch 20  train_mse 0.0723  test_mse 0.0781
+epoch 30  train_mse 0.0333  test_mse 0.0470
+epoch 39  train_mse 0.0255  test_mse 0.0382
+held-out forecast MSE (first window): 0.0385
+forecast[:4] [0.725 0.705 0.684 0.955]  truth[:4] [0.62  0.71  0.6   0.968]
+```
+
+The forecast on the first held-out window tracks the true continuation closely — the predicted values sit right next to the ground truth in standardized units. Environment knobs `EPOCHS`, `BATCH`, and `SYNTHETIC` scale the run; `SYNTHETIC=0` uses a longer 2048-step series.
+
+## Common Pitfalls
+
+- ❌ Feeding a flat `(B, L)` window into `nnx.RNN` and getting a shape error.
+  ✅ The RNN needs a feature axis: reshape to `(B, L, 1)` for univariate input (stack channels for multivariate).
+
+- ❌ Standardizing the whole series (or the test split) with global mean/std.
+  ✅ Compute statistics on the **training region only** and reuse them — future stats leak information you won't have at inference.
+
+- ❌ Predicting one step and calling `H` steps done, or looping the model on its own noisy outputs without training for it.
+  ✅ Emit all `H` values at once with a `nnx.Linear(hidden, H)` head (direct multi-step) so every horizon step gets its own trained weights.
+
+- ❌ Reaching for `compute_cross_entropy_loss` because other sequence guides use it.
+  ✅ Forecasting is regression over continuous values — use **MSE** (`compute_mse_loss`).
+
+- ❌ Judging quality by raw MSE alone.
+  ✅ Compare against a **naive persistence baseline** (repeat the last observed value); a useful model must beat it.
+
+## Next steps
+
+- [Word2Vec](/applications/sequence/word2vec) — learn dense representations from sequences instead of forecasting them.
+- [Simple Transformer](/basics/text/simple-transformer) — attention replaces the recurrent scan and forecasts every position in parallel.
+
+## Complete Example
+
+Full runnable script with the synthetic series, sliding-window builder, time-based split, and training loop: [`examples/sequence/time_series.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/time_series.py).
+
+## References
+
+- Hochreiter & Schmidhuber (1997), *Long Short-Term Memory* — [Neural Computation 9(8)](https://doi.org/10.1162/neco.1997.9.8.1735).
+- Lim & Zohren (2020), *Time Series Forecasting With Deep Learning: A Survey* — [arXiv:2004.13408](https://arxiv.org/abs/2004.13408).
+- Salinas et al. (2019), *DeepAR: Probabilistic Forecasting with Autoregressive Recurrent Networks* — [arXiv:1704.04110](https://arxiv.org/abs/1704.04110).
+- Hewamalage, Bergmeir & Bandara (2019), *Recurrent Neural Networks for Time Series Forecasting: Current Status and Future Directions* — [arXiv:1909.00590](https://arxiv.org/abs/1909.00590).

--- a/website/docs/applications/sequence/word2vec.md
+++ b/website/docs/applications/sequence/word2vec.md
@@ -1,0 +1,234 @@
+---
+sidebar_position: 4
+title: Word2Vec Skip-Gram with Negative Sampling in NNX
+description: "Train Word2Vec skip-gram embeddings with negative sampling in Flax NNX using two nnx.Embed tables, then recover semantic clusters with cosine nearest neighbours."
+keywords: [word2vec, skip-gram, negative sampling, SGNS, word embeddings, nnx.Embed, flax nnx, jax, cosine similarity, nearest neighbours, distributional semantics]
+image: img/docusaurus-social-card.jpg
+---
+
+# Word2Vec: Skip-Gram with Negative Sampling
+
+**Turn words into geometry.** Word2Vec learns a dense vector for every word so that words used in similar contexts land near each other. This guide builds the skip-gram with negative sampling (SGNS) model in Flax NNX from two `nnx.Embed` tables, derives the negative-sampling loss, trains on a tiny self-contained corpus, and shows the learned clusters via cosine nearest neighbours.
+
+:::note Prerequisites
+You should be comfortable defining a module and running a training loop — see [your first model](/basics/fundamentals/your-first-model). Word2Vec is the embedding layer of the sequence family, so the [recurrent networks](/applications/sequence/recurrent-networks) guide is good background on how tokens become vectors.
+:::
+
+:::tip What you'll learn
+- The **skip-gram objective** — predict context words from a center word
+- Why full softmax is intractable and how **negative sampling** replaces it
+- How to build SGNS from **two `nnx.Embed` tables** (input + output vectors)
+- The **negative-sampling loss** written as a numerically stable sigmoid BCE
+- How to read out embeddings and probe them with **cosine nearest neighbours**
+:::
+
+:::info Example Code
+See the full implementation: [`examples/sequence/word2vec.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/word2vec.py)
+:::
+
+## The distributional hypothesis
+
+> "You shall know a word by the company it keeps." — J.R. Firth
+
+Word2Vec operationalizes this idea: a word's meaning is captured by the distribution of words that surround it. If *king* and *queen* appear in the same slots — next to *royal*, *throne*, *palace* — their vectors should be close. We never label anything; the corpus's own co-occurrence statistics are the supervision.
+
+### The skip-gram model
+
+Skip-gram frames it as a prediction task: given a **center** word $w_c$, predict each **context** word $w_o$ within a window of size $m$. Over a corpus of length $T$ the objective is to maximize the average log-probability of the true context words:
+
+$$
+\frac{1}{T} \sum_{t=1}^{T} \sum_{-m \le j \le m,\, j \ne 0} \log P(w_{t+j} \mid w_t)
+$$
+
+The natural choice for $P$ is a softmax over the whole vocabulary,
+
+$$
+P(w_o \mid w_c) = \frac{\exp(u_{w_o}^\top v_{w_c})}{\sum_{w=1}^{V} \exp(u_{w}^\top v_{w_c})},
+$$
+
+where each word has **two** vectors: an *input* vector $v_w$ (used when it is the center) and an *output* vector $u_w$ (used when it is a context). The problem: that denominator sums over the entire vocabulary $V$, so every gradient step costs $O(V)$. For real vocabularies (millions of words) this is hopeless.
+
+## Negative sampling
+
+Negative sampling replaces the expensive softmax with a much cheaper **binary** problem. Instead of asking "which of all $V$ words is the context?", we ask "is this specific (center, context) pair real, or fake?" For each true pair we draw $K$ **negative** words from a noise distribution and train the model to tell the real pair apart from the fakes.
+
+The loss for a single positive pair $(w_c, w_o)$ with negatives $w_{n_1}, \dots, w_{n_K}$ is
+
+$$
+\mathcal{L} = -\log \sigma\!\left(u_{w_o}^\top v_{w_c}\right) \;-\; \sum_{k=1}^{K} \log \sigma\!\left(-u_{w_{n_k}}^\top v_{w_c}\right)
+$$
+
+where $\sigma(x) = 1/(1 + e^{-x})$ is the logistic sigmoid. The first term pushes the score of the true pair **up** (toward $\sigma \to 1$); each second term pushes a random pair's score **down** (toward $\sigma \to 0$). This is exactly a sigmoid **binary cross-entropy** with label $1$ for the true context and $0$ for the negatives — but summed over only $K + 1$ words instead of $V$.
+
+The original paper samples negatives from the unigram distribution raised to the $3/4$ power, $P_n(w) \propto \text{count}(w)^{0.75}$, which slightly boosts rare words. On a small balanced vocabulary, uniform sampling works fine and keeps the demo transparent.
+
+## Building the model in Flax NNX
+
+The model is just the two vector tables — `center` holds the input vectors $v_w$, `context` holds the output vectors $u_w$. The forward pass looks up the center vector, the positive context vector, and the $K$ negative vectors, then returns their dot-product scores.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+
+class SkipGramNS(nnx.Module):
+    def __init__(self, vocab_size, dim, *, rngs: nnx.Rngs):
+        self.center = nnx.Embed(vocab_size, dim, rngs=rngs)   # input vectors v_w
+        self.context = nnx.Embed(vocab_size, dim, rngs=rngs)  # output vectors u_w
+
+    def __call__(self, center_ids, context_ids, negative_ids):
+        v_c = self.center(center_ids)              # (B, D)    center vectors
+        u_o = self.context(context_ids)            # (B, D)    positive contexts
+        u_n = self.context(negative_ids)           # (B, K, D) negatives
+        pos_score = jnp.sum(v_c * u_o, axis=-1)                 # (B,)
+        neg_score = jnp.einsum("bd,bkd->bk", v_c, u_n)          # (B, K)
+        return pos_score, neg_score
+
+    def word_vectors(self):
+        return self.center.embedding[...]          # (vocab, D) — the vectors you keep
+```
+
+After training we export the **center** table as the word vectors (a common alternative is to average `center + context`).
+
+### The negative-sampling loss
+
+Written with `jax.nn.log_sigmoid` — the numerically stable `log(sigmoid(x))` — the loss is a direct transcription of the math above:
+
+```python
+def sgns_loss(pos_score, neg_score):
+    pos = -jax.nn.log_sigmoid(pos_score)                  # true pair -> score high
+    neg = -jax.nn.log_sigmoid(-neg_score).sum(axis=-1)   # negatives -> scores low
+    return jnp.mean(pos + neg)
+```
+
+## Preparing the data
+
+There is nothing to download: a handful of themed sentences are hardcoded in the script. We tokenize, drop a small stopword set (the tutorial-sized version of Word2Vec's frequent-word subsampling), and slide a window over each sentence to emit `(center, context)` pairs.
+
+```python
+def build_skipgram_pairs(corpus, stoi, window=2):
+    centers, contexts = [], []
+    for line in corpus:
+        ids = [stoi[w] for w in tokenize(line)]        # tokenize drops stopwords
+        for i, center in enumerate(ids):
+            lo, hi = max(0, i - window), min(len(ids), i + window + 1)
+            for j in range(lo, hi):
+                if j != i:
+                    centers.append(center)
+                    contexts.append(ids[j])
+    return np.asarray(centers, np.int32), np.asarray(contexts, np.int32)
+
+
+def sample_negatives(key, n, vocab_size, k):
+    return jax.random.randint(key, (n, k), 0, vocab_size).astype(jnp.int32)
+```
+
+The corpus is built from four disjoint themes — royalty, ocean, space, music — whose words co-occur with each other but never across themes. That gives skip-gram a clean signal and makes the learned clusters easy to see.
+
+## The training step
+
+Standard NNX: `nnx.value_and_grad` with `has_aux=True` so we can return the scores alongside the loss, then `optimizer.update(model, grads)`. Fresh negatives are sampled every step, so the model sees new noise each time.
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        pos_score, neg_score = model(
+            batch["center"], batch["context"], batch["negatives"]
+        )
+        loss = sgns_loss(pos_score, neg_score)
+        return loss, (pos_score, neg_score)
+
+    (loss, aux), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, aux
+```
+
+Build the model and optimizer explicitly, then loop over shuffled minibatches:
+
+```python
+model = SkipGramNS(vocab_size, dim=32, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(5e-2), wrt=nnx.Param)
+
+for step in range(40):
+    key, nkey = jax.random.split(key)
+    batch = {
+        "center": centers,
+        "context": contexts,
+        "negatives": sample_negatives(nkey, n_pairs, vocab_size, K),
+    }
+    loss, _ = train_step(model, optimizer, batch)
+```
+
+## Probing the embeddings
+
+The payoff is geometric: after training, the **cosine similarity** between word vectors reflects semantic relatedness.
+
+$$
+\text{sim}(a, b) = \frac{v_a^\top v_b}{\lVert v_a \rVert \, \lVert v_b \rVert}
+$$
+
+```python
+def nearest_neighbors(vectors, itos, word, stoi, k=5):
+    normed = vectors / (jnp.linalg.norm(vectors, axis=1, keepdims=True) + 1e-8)
+    sims = normed @ normed[stoi[word]]
+    order = jnp.argsort(sims)[::-1]
+    return [(itos[i], float(sims[i])) for i in order.tolist()
+            if itos[i] != word][:k]
+```
+
+## Results / What to Expect
+
+The negative-sampling loss drops from ~4.9 to well under 1.5 within 40 steps, and every probe word's nearest neighbours come from its own theme — `king` pulls in `queen` and `royal`, `ocean` pulls in `sail` and `fish`:
+
+```console
+$ python sequence/word2vec.py
+vocab=49 pairs=324 dim=32 neg=6 epochs=200 batch=128
+epoch   0  loss 4.7754
+epoch  20  loss 1.3206
+epoch 100  loss 1.2696
+epoch 199  loss 1.2935
+
+Nearest neighbours (cosine):
+  king     -> queen:0.72, rule:0.69, palace:0.68, princess:0.65
+  ocean    -> sail:0.80, sailor:0.63, wave:0.61, fish:0.60
+  rocket   -> star:0.76, planet:0.64, comet:0.64, reach:0.58
+  guitar   -> song:0.74, blend:0.67, drum:0.65, singer:0.62
+```
+
+The loss plateaus rather than going to zero — that is expected. With random negatives there is always residual noise the model cannot (and should not) fit; the useful signal is in the **relative geometry** of the vectors, not the absolute loss. Environment knobs `EPOCHS`, `BATCH`, `DIM`, `WINDOW`, and `NEG` let you scale the run.
+
+## Common Pitfalls
+
+- ❌ Using one embedding table and dotting a word with itself.
+  ✅ Skip-gram keeps **two** tables (`center` for input, `context` for output); the score is `center(w_c) · context(w_o)`.
+
+- ❌ Computing the loss with a full softmax over the vocabulary.
+  ✅ That is $O(V)$ per step. Use **negative sampling**: one positive plus $K$ sampled negatives, scored with a sigmoid.
+
+- ❌ Applying `sigmoid` then `log` by hand and hitting `NaN`s from `log(0)`.
+  ✅ Use `jax.nn.log_sigmoid(x)` and `jax.nn.log_sigmoid(-x)` — the stable form of `log σ`.
+
+- ❌ Reusing the **same** negatives every step.
+  ✅ Resample negatives each step (split a fresh `jax.random.key`) so the model sees varied noise.
+
+- ❌ Putting a Python list of embedding tables in a plain attribute to hold many tables.
+  ✅ On Flax 0.12 wrap submodule lists in `nnx.List([...])` (and dicts in `nnx.Dict({...})`) so they register as state.
+
+## Next steps
+
+- [Simple Transformer](/basics/text/simple-transformer) — contextual embeddings replace one-vector-per-word with representations that depend on the whole sentence.
+- [CLIP](/applications/adaptation/clip) — the same "pull matching pairs together, push mismatches apart" idea, scaled up to align images and text.
+
+## Complete Example
+
+Full runnable script — corpus, vocab, skip-gram pairs, negative sampling, the SGNS model, training loop, and cosine nearest neighbours: [`examples/sequence/word2vec.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/sequence/word2vec.py).
+
+## References
+
+- Mikolov et al. (2013), *Efficient Estimation of Word Representations in Vector Space* — [arXiv:1301.3781](https://arxiv.org/abs/1301.3781).
+- Mikolov et al. (2013), *Distributed Representations of Words and Phrases and their Compositionality* (negative sampling) — [arXiv:1310.4546](https://arxiv.org/abs/1310.4546).
+- Goldberg & Levy (2014), *word2vec Explained: Deriving Mikolov et al.'s Negative-Sampling Word-Embedding Method* — [arXiv:1402.3722](https://arxiv.org/abs/1402.3722).
+- Levy & Goldberg (2014), *Neural Word Embedding as Implicit Matrix Factorization* — [NeurIPS 2014](https://papers.nips.cc/paper/2014/hash/feab05aa91085b7a8012516bc3533958-Abstract.html).

--- a/website/docs/applications/vision/index.md
+++ b/website/docs/applications/vision/index.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 0
+title: Advanced Vision in Flax NNX
+description: Build a Vision Transformer (ViT) and a U-Net for segmentation in Flax NNX — vision beyond CNNs, with attention and dense per-pixel prediction.
+keywords: [vision transformer, ViT, U-Net, semantic segmentation, flax nnx, jax, attention, dense prediction]
+---
+
+# Advanced Vision
+
+CNNs and ResNets are the workhorses of image classification, but they aren't the
+whole story. This track covers two architectures that go beyond the convolutional
+backbone: the **Vision Transformer**, which brings attention to images, and the
+**U-Net**, which produces a full-resolution output for dense prediction.
+
+## What you'll build
+
+- **[Vision Transformer (ViT)](/applications/vision/vision-transformer)** —
+  split an image into patches, embed them as tokens, and classify with a
+  transformer encoder. A global receptive field from the very first layer, using
+  the built-in `nnx.MultiHeadAttention`.
+- **[U-Net Segmentation](/applications/vision/unet-segmentation)** — an
+  encoder-decoder with skip connections that labels *every pixel*, using
+  `nnx.ConvTranspose` to upsample back to full resolution.
+
+## Prerequisites
+
+You should have built a [CNN](/basics/vision/simple-cnn) and understand
+[transformers](/basics/text/simple-transformer) (ViT reuses the encoder) and
+[ResNet skip connections](/basics/vision/resnet-architecture) (U-Net generalizes them).
+
+## Next steps
+
+- Start with the [Vision Transformer](/applications/vision/vision-transformer).
+- The [U-Net](/applications/vision/unet-segmentation) is also the denoiser
+  backbone behind [diffusion models](/applications/generative/diffusion).

--- a/website/docs/applications/vision/unet-segmentation.md
+++ b/website/docs/applications/vision/unet-segmentation.md
@@ -1,0 +1,319 @@
+---
+sidebar_position: 2
+title: U-Net Semantic Segmentation in Flax NNX
+description: "Build a full U-Net in Flax NNX for per-pixel segmentation: encoder-decoder with skip connections, nnx.ConvTranspose upsampling, and a sigmoid-BCE loss."
+keywords: [u-net, semantic segmentation, flax nnx, jax, encoder decoder, skip connections, ConvTranspose, dense prediction, IoU, Dice]
+---
+
+# U-Net Semantic Segmentation
+
+Label *every pixel*, not just the whole image: a U-Net takes an image in and
+returns a same-size map of per-pixel predictions.
+
+:::note Prerequisites
+This guide builds directly on the encoder-decoder idea from the
+[Autoencoder](/applications/generative/autoencoder) (the decoder here upsamples
+the very same way) and on convolutional building blocks from the
+[Simple CNN](/basics/vision/simple-cnn) and
+[ResNet architecture](/basics/vision/resnet-architecture) guides (U-Net's skip
+connections generalize residual connections).
+:::
+
+:::tip What you'll learn
+- What **dense (per-pixel) prediction** is and how it differs from classification
+- How to build the U-Net **encoder-decoder** with a contracting and an expanding path
+- Why **skip connections** that concatenate encoder features are the whole point
+- Upsampling with **`nnx.ConvTranspose`** back to the input resolution
+- Training with **per-pixel sigmoid BCE** and measuring quality with **IoU / Dice**
+:::
+
+:::info Example Code
+See the full, runnable implementation:
+[`examples/vision/unet_segmentation.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/vision/unet_segmentation.py)
+:::
+
+## The Motivation
+
+A classifier answers *"what is in this image?"* with a single label. **Semantic
+segmentation** answers a much harder question — *"what is at every pixel?"* — by
+producing an output map the same height and width as the input, where each pixel
+carries its own prediction. That is exactly what you need for medical imaging,
+autonomous driving, satellite analysis, and background removal.
+
+The difficulty is a tension between two things:
+
+- **Context**: to know *what* a pixel is, the network needs a large receptive
+  field, which means downsampling to see the big picture.
+- **Localization**: to know *where* an object's boundary lies, the network needs
+  full-resolution detail, which downsampling throws away.
+
+U-Net (Ronneberger et al., 2015) resolves the tension with a symmetric
+**encoder-decoder** plus **skip connections**. The encoder downsamples to gather
+context; the decoder upsamples back to full resolution; and skip connections
+splice the encoder's high-resolution features directly into the decoder so fine
+boundaries are never lost. Drawn out, the data flow makes a "U" — hence the name.
+
+## The Architecture
+
+$$
+\underbrace{x \to \text{enc}_1 \to \text{enc}_2}_{\text{contracting (context)}}
+\;\to\;
+\underbrace{\text{bottleneck}}_{\text{coarsest}}
+\;\to\;
+\underbrace{\text{dec}_2 \to \text{dec}_1 \to \hat{y}}_{\text{expanding (localization)}}
+$$
+
+Each decoder stage $\text{dec}_i$ does not just consume the layer below it — it
+**concatenates** the matching encoder features $s_i$ along the channel axis:
+
+$$
+\text{dec}_i = \text{DoubleConv}\big(\;[\,\text{Upsample}(\cdot)\;\Vert\; s_i\,]\;\big).
+$$
+
+That concatenation ($\Vert$) is the skip connection. It hands the decoder the
+sharp, high-resolution activations the encoder computed *before* pooling them
+away, which is what lets a U-Net trace crisp object boundaries.
+
+### The building block: a double conv
+
+Every stage is a `(Conv → GroupNorm → ReLU) × 2` block at a fixed resolution. We
+use `nnx.GroupNorm` rather than `nnx.BatchNorm` so normalization is
+batch-independent — convenient with `nnx.jit` and the small batches you'll run on
+CPU. Keep channel counts divisible by `num_groups`.
+
+```python
+import jax, jax.numpy as jnp
+from flax import nnx
+
+class DoubleConv(nnx.Module):
+    """(Conv -> GroupNorm -> ReLU) x 2 at a fixed spatial resolution."""
+    def __init__(self, in_ch, out_ch, *, num_groups=8, rngs):
+        self.conv1 = nnx.Conv(in_ch, out_ch, kernel_size=(3, 3), padding='SAME', rngs=rngs)
+        self.norm1 = nnx.GroupNorm(out_ch, num_groups=num_groups, rngs=rngs)
+        self.conv2 = nnx.Conv(out_ch, out_ch, kernel_size=(3, 3), padding='SAME', rngs=rngs)
+        self.norm2 = nnx.GroupNorm(out_ch, num_groups=num_groups, rngs=rngs)
+
+    def __call__(self, x):
+        x = nnx.relu(self.norm1(self.conv1(x)))
+        x = nnx.relu(self.norm2(self.conv2(x)))
+        return x
+```
+
+### The U-Net
+
+The encoder halves the resolution twice with `nnx.max_pool`; the bottleneck runs
+at the coarsest scale; and the decoder upsamples with `nnx.ConvTranspose`,
+concatenating the stored skip at each step. A final `1×1` conv projects to
+per-pixel logits — one channel here, since the task is binary foreground vs.
+background.
+
+```python
+class UNet(nnx.Module):
+    """A 2-level U-Net for binary semantic segmentation."""
+    def __init__(self, in_channels=1, out_channels=1, base=16, *, rngs):
+        # Encoder (contracting path)
+        self.enc1 = DoubleConv(in_channels, base, rngs=rngs)        # full res
+        self.enc2 = DoubleConv(base, base * 2, rngs=rngs)           # 1/2 res
+        # Bottleneck
+        self.bottleneck = DoubleConv(base * 2, base * 4, rngs=rngs)  # 1/4 res
+        # Decoder (expanding path): ConvTranspose doubles resolution; the
+        # following DoubleConv sees upsampled features ++ encoder skip (2x in_ch).
+        self.up2 = nnx.ConvTranspose(base * 4, base * 2, kernel_size=(3, 3),
+                                     strides=(2, 2), padding='SAME', rngs=rngs)
+        self.dec2 = DoubleConv(base * 4, base * 2, rngs=rngs)       # concat -> base*4
+        self.up1 = nnx.ConvTranspose(base * 2, base, kernel_size=(3, 3),
+                                     strides=(2, 2), padding='SAME', rngs=rngs)
+        self.dec1 = DoubleConv(base * 2, base, rngs=rngs)          # concat -> base*2
+        # 1x1 conv -> per-pixel class logits (no activation)
+        self.out_conv = nnx.Conv(base, out_channels, kernel_size=(1, 1), rngs=rngs)
+
+    def __call__(self, x, train=False):
+        # Encoder: store s1, s2 as skip sources BEFORE each downsample.
+        s1 = self.enc1(x)                                          # (B,H,  W,  base)
+        s2 = self.enc2(nnx.max_pool(s1, (2, 2), strides=(2, 2)))   # (B,H/2,W/2,base*2)
+        b = self.bottleneck(nnx.max_pool(s2, (2, 2), strides=(2, 2)))  # (B,H/4,..,base*4)
+        # Decoder: upsample, concatenate the skip, then DoubleConv.
+        d2 = self.up2(b)                                           # (B,H/2,W/2,base*2)
+        d2 = self.dec2(jnp.concatenate([d2, s2], axis=-1))         # skip 2
+        d1 = self.up1(d2)                                          # (B,H,  W,  base)
+        d1 = self.dec1(jnp.concatenate([d1, s1], axis=-1))         # skip 1
+        return self.out_conv(d1)                                   # (B,H,W,out) logits
+```
+
+:::note Why concatenate instead of add?
+A ResNet block *adds* its skip (`x + f(x)`), which requires matching channel
+counts and fuses the two signals. U-Net *concatenates* (`[a ‖ b]`), preserving
+both the upsampled semantic features and the raw encoder detail as separate
+channels for the next conv to mix as it sees fit. That is why the decoder's
+`DoubleConv` takes twice the channels it outputs.
+:::
+
+## The Loss: Per-Pixel Sigmoid BCE
+
+Binary segmentation is just binary classification repeated at every pixel. With
+logits $z_p$ and ground-truth mask $y_p \in \{0,1\}$ over pixels $p$,
+
+$$
+\mathcal{L} = \frac{1}{B}\sum_{b} \sum_{p} \Big[ -y_p \log \sigma(z_p) - (1-y_p)\log\big(1-\sigma(z_p)\big) \Big].
+$$
+
+The shared `bce_loss` helper already applies `optax.sigmoid_binary_cross_entropy`
+and sums over pixels — it works directly on 4-D `(B, H, W, 1)` tensors. The train
+step is the textbook NNX pattern: `nnx.value_and_grad` with `has_aux=True`, then
+`optimizer.update`.
+
+```python
+from shared.training_utils import bce_loss
+
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch['image'], train=True)   # (B, H, W, 1)
+        loss = bce_loss(logits, batch['mask'])        # per-pixel sigmoid BCE
+        return loss, logits
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, logits
+```
+
+Build the model and optimizer with explicit RNGs and the modern `wrt=nnx.Param`
+optimizer API:
+
+```python
+import optax
+model = UNet(in_channels=1, out_channels=1, base=16, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+## Measuring Quality: IoU and Dice
+
+Raw BCE is hard to interpret and, because most pixels are background, a lazy
+all-background predictor can post a deceptively low loss. Segmentation is scored
+with **overlap** metrics between the thresholded prediction $P$ and ground truth
+$G$:
+
+$$
+\text{IoU} = \frac{|P \cap G|}{|P \cup G|}, \qquad
+\text{Dice} = \frac{2\,|P \cap G|}{|P| + |G|}.
+$$
+
+```python
+def iou_dice(logits, masks, threshold=0.5, eps=1e-6):
+    preds = (jax.nn.sigmoid(logits) > threshold).astype(jnp.float32)
+    axes = (1, 2, 3)
+    inter = jnp.sum(preds * masks, axis=axes)
+    p_area, g_area = jnp.sum(preds, axis=axes), jnp.sum(masks, axis=axes)
+    union = p_area + g_area - inter
+    iou = jnp.mean((inter + eps) / (union + eps))
+    dice = jnp.mean((2.0 * inter + eps) / (p_area + g_area + eps))
+    return iou, dice
+```
+
+## The Data: Synthetic Shapes
+
+No downloads needed. We drop a few bright circles and squares on a dim, noisy
+background; the mask is `1` wherever a shape covers a pixel. Everything is built
+with `jax.random`, so the whole example runs offline.
+
+```python
+def make_dataset(n=128, size=32, max_shapes=3, seed=0):
+    key = jax.random.key(seed)
+    k_cy, k_cx, k_r, k_shape, k_noise = jax.random.split(key, 5)
+    coords = jnp.arange(size, dtype=jnp.float32)
+    gy, gx = jnp.meshgrid(coords, coords, indexing='ij')       # (size, size)
+
+    margin = 0.18 * size
+    cy = jax.random.uniform(k_cy, (n, max_shapes), minval=margin, maxval=size - margin)
+    cx = jax.random.uniform(k_cx, (n, max_shapes), minval=margin, maxval=size - margin)
+    radius = jax.random.uniform(k_r, (n, max_shapes), minval=0.09 * size, maxval=0.20 * size)
+    is_circle = jax.random.bernoulli(k_shape, 0.5, (n, max_shapes))
+
+    dy = gy[None, None] - cy[..., None, None]                  # (n, K, H, W)
+    dx = gx[None, None] - cx[..., None, None]
+    r = radius[..., None, None]
+    circ = (dy ** 2 + dx ** 2) <= r ** 2                       # disk
+    square = (jnp.abs(dy) <= r) & (jnp.abs(dx) <= r)           # axis-aligned box
+    per_shape = jnp.where(is_circle[..., None, None], circ, square)
+    mask = jnp.any(per_shape, axis=1).astype(jnp.float32)      # (n, H, W) union
+
+    noise = 0.05 * jax.random.normal(k_noise, (n, size, size))
+    image = jnp.clip(0.15 + 0.70 * mask + noise, 0.0, 1.0)
+    return image[..., None], mask[..., None]                   # (n, H, W, 1) each
+```
+
+## Results / What to Expect
+
+The verification harness builds the model, checks the output resolution matches
+the input, and trains 40 steps on a fixed batch. The BCE drops sharply and the
+IoU climbs from near-zero (a random init predicts nearly nothing) to well above
+0.9 — the shapes are cleanly segmented:
+
+```text
+params: 130,193
+input shape:  (8, 32, 32, 1)
+output shape: (8, 32, 32, 1)
+loss[0]=736.512  loss[-1]=172.046
+IoU[0]=0.130  IoU[-1]=0.972
+loss trace (every 8): [736.51, 343.26, 263.61, 215.21, 188.82]
+IoU  trace (every 8): [0.13, 0.897, 0.934, 0.951, 0.961]
+final IoU=0.972  Dice=0.986
+
+ALL ASSERTS PASSED
+```
+
+The full script (`python vision/unet_segmentation.py`) trains a few epochs over a
+fresh synthetic dataset and reports IoU/Dice each epoch:
+
+```text
+  epoch  1/3 | BCE   580.57 | IoU 0.808 | Dice 0.893
+  epoch  2/3 | BCE   389.29 | IoU 0.887 | Dice 0.939
+  epoch  3/3 | BCE   329.37 | IoU 0.915 | Dice 0.954
+```
+
+Because the crucial signal is *segmentation overlap* rather than the raw loss
+value, we assert that **IoU improves** (and ends above 0.5), not merely that the
+loss goes down.
+
+## Common Pitfalls
+
+**Dropping the skip connections**
+❌ A plain encoder-decoder without skips produces blurry, misplaced boundaries.
+✅ `jnp.concatenate([upsampled, skip], axis=-1)` at every decoder stage.
+
+**Channel-count mismatch after concatenation**
+❌ Sizing the decoder `DoubleConv` for the upsampled features only.
+✅ Its `in_ch` is `upsampled_ch + skip_ch` (here `base*2 + base*2 = base*4`).
+
+**Judging the model by BCE alone**
+❌ Background dominates, so an all-zero mask can post a low loss.
+✅ Track **IoU / Dice**, which reward actual overlap with the target.
+
+**Applying sigmoid before the loss**
+❌ Feeding probabilities into `sigmoid_binary_cross_entropy` double-counts it.
+✅ Return raw **logits** from `out_conv`; the loss applies the sigmoid internally.
+
+**BatchNorm with tiny CPU batches**
+❌ `nnx.BatchNorm` needs the `use_running_average` train/eval dance and wobbles on small batches.
+✅ `nnx.GroupNorm` normalizes per-group, batch-independently (channels divisible by `num_groups`).
+
+## Next steps
+
+- [Diffusion Models (DDPM)](/applications/generative/diffusion) — the same
+  encoder-decoder-with-skips U-Net becomes a time-conditioned *denoiser*; this
+  guide is the "full" version its compact inline U-Net points back to.
+- [Vision Transformer (ViT)](/applications/vision/vision-transformer) — an
+  attention-based alternative backbone for dense and global image tasks.
+
+## Complete Example
+
+- [`examples/vision/unet_segmentation.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/vision/unet_segmentation.py)
+  — a complete, CPU-verifiable U-Net: synthetic shape/mask generator,
+  encoder-decoder with concatenating skip connections, `nnx.ConvTranspose`
+  upsampling, sigmoid-BCE training step, and IoU/Dice metrics.
+
+## References
+
+- **U-Net**: [U-Net: Convolutional Networks for Biomedical Image Segmentation](https://arxiv.org/abs/1505.04597) (Ronneberger, Fischer & Brox, 2015)
+- **Fully Convolutional Networks**: [Fully Convolutional Networks for Semantic Segmentation](https://arxiv.org/abs/1411.4038) (Long, Shelhamer & Darrell, 2015)
+- **Group Normalization**: [Group Normalization](https://arxiv.org/abs/1803.08494) (Wu & He, 2018)
+- **3D U-Net**: [3D U-Net: Learning Dense Volumetric Segmentation](https://arxiv.org/abs/1606.06650) (Çiçek et al., 2016)

--- a/website/docs/applications/vision/vision-transformer.md
+++ b/website/docs/applications/vision/vision-transformer.md
@@ -1,0 +1,229 @@
+---
+sidebar_position: 1
+title: Vision Transformer (ViT) Classifier in Flax NNX
+description: "Build a Vision Transformer (ViT) in Flax NNX: patchify images, prepend a CLS token with learned positional embeddings, and classify with a transformer encoder."
+keywords: [vision transformer, ViT, flax nnx, jax, patch embedding, self-attention, CLS token, image classification, MNIST]
+---
+
+# Vision Transformer (ViT)
+
+Treat an image as a short sequence of patches and let self-attention do the rest — a transformer, not a convolution, learns to classify.
+
+:::note Prerequisites
+This guide builds on [Simple CNN](/basics/vision/simple-cnn) for the image-classification setup, [Text Generation with Transformers](/basics/text/simple-transformer) for self-attention, and [ResNet Architecture](/architectures/resnet) for the convolutional baseline we contrast against.
+:::
+
+:::tip What you'll learn
+- Patchify a 28×28 image into non-overlapping 7×7 patches with a single strided `nnx.Conv`
+- Prepend a learned **CLS token** and add learned **positional embeddings** stored as `nnx.Param`
+- Stack pre-norm transformer encoder blocks (reusing the shared `TransformerBlock`) with `nnx.List`
+- Classify from the CLS token and train with cross-entropy
+- Understand why ViTs have a **global receptive field from layer 1** — and why that makes them data-hungry vs CNNs
+:::
+
+:::info Example Code
+Full runnable script: [`examples/vision/vit.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/vision/vit.py)
+:::
+
+## Why a transformer for images?
+
+A CNN processes an image with small kernels that only see a local neighborhood; a pixel on the left of the image cannot influence one on the right until many layers of pooling have shrunk the spatial grid. A **Vision Transformer** takes the opposite stance: it chops the image into a handful of patches, treats them as a sequence of tokens, and applies self-attention so that *every patch can attend to every other patch in the very first layer*. The receptive field is global immediately.
+
+The recipe (from Dosovitskiy et al., 2020) is short:
+
+1. **Patchify** the image into $N$ non-overlapping patches.
+2. **Linearly embed** each patch into a $D$-dimensional token.
+3. **Prepend** a special learnable classification (CLS) token and **add** learned positional embeddings.
+4. Run a standard **transformer encoder**.
+5. Read the final CLS token and send it through a linear **classification head**.
+
+### Patch embedding
+
+Split an image $x \in \mathbb{R}^{H \times W \times C}$ into $N = HW / P^2$ patches of size $P \times P$. Each patch is flattened to $\mathbb{R}^{P^2 C}$ and projected by a shared matrix $E \in \mathbb{R}^{(P^2 C) \times D}$. We prepend a learnable token $x_\text{cls}$ and add positional embeddings $E_\text{pos}$:
+
+$$
+z_0 = \big[\, x_\text{cls};\ x_p^1 E;\ x_p^2 E;\ \dots;\ x_p^N E \,\big] + E_\text{pos},
+\qquad E_\text{pos} \in \mathbb{R}^{(N+1) \times D}.
+$$
+
+For our $28\times28$ MNIST-sized image with patch size $P=7$, there are $N = (28/7)^2 = 16$ patches, so the sequence has $N+1 = 17$ tokens (16 patches + CLS). Applying a convolution with kernel size $P$ and **stride** $P$ computes exactly one linear map per non-overlapping patch, which is why patch embedding is just a strided `nnx.Conv`.
+
+### Self-attention
+
+Inside each encoder block, tokens mix through scaled dot-product attention:
+
+$$
+\text{Attention}(Q, K, V) = \operatorname{softmax}\!\left(\frac{Q K^\top}{\sqrt{d_k}}\right) V.
+$$
+
+Because $Q K^\top$ is an $(N+1) \times (N+1)$ matrix, every token — including the CLS token — forms a weighted combination of *all* tokens. There is no locality prior baked in; attention learns which patches matter. Positional embeddings are what tell the otherwise permutation-invariant attention *where* each patch came from.
+
+## Patchifying the image
+
+We implement patch embedding as one strided convolution and flatten the resulting grid into a sequence.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+from shared.models import TransformerBlock
+from shared.training_utils import compute_cross_entropy_loss, compute_accuracy
+
+
+class PatchEmbed(nnx.Module):
+    """Split an image into non-overlapping patches and linearly embed each one."""
+
+    def __init__(self, patch_size: int, in_channels: int, dim: int, *, rngs: nnx.Rngs):
+        self.proj = nnx.Conv(
+            in_channels, dim,
+            kernel_size=(patch_size, patch_size),
+            strides=(patch_size, patch_size),
+            padding="VALID",                    # non-overlapping patches
+            rngs=rngs,
+        )
+
+    def __call__(self, x):
+        x = self.proj(x)                        # (B, H/p, W/p, dim)
+        b, h, w, d = x.shape
+        return x.reshape(b, h * w, d)           # (B, num_patches, dim)
+```
+
+The `padding="VALID"` plus `strides=(patch_size, patch_size)` is the whole trick: the kernel lands on each patch exactly once with no overlap, so a $28\times28$ image becomes a $4\times4$ grid, flattened to 16 patch tokens.
+
+## Building the ViT
+
+The CLS token and positional embeddings are plain learnable arrays — we store them as `nnx.Param`. The encoder is a stack of the shared `TransformerBlock`, wrapped in `nnx.List` so Flax tracks the submodules correctly.
+
+```python
+class ViT(nnx.Module):
+    def __init__(self, *, image_size=28, patch_size=7, in_channels=1, num_classes=10,
+                 dim=64, depth=4, num_heads=4, mlp_dim=128, dropout=0.1, rngs: nnx.Rngs):
+        num_patches = (image_size // patch_size) ** 2      # 16
+
+        self.patch_embed = PatchEmbed(patch_size, in_channels, dim, rngs=rngs)
+
+        # Learned CLS token and positional embeddings, small-scale init (0.02).
+        self.cls_token = nnx.Param(0.02 * jax.random.normal(rngs.params(), (1, 1, dim)))
+        self.pos_embed = nnx.Param(
+            0.02 * jax.random.normal(rngs.params(), (1, num_patches + 1, dim))
+        )
+
+        # A stack of pre-norm encoder blocks. MUST be nnx.List on Flax 0.12.
+        self.blocks = nnx.List([
+            TransformerBlock(d_model=dim, num_heads=num_heads, d_ff=mlp_dim,
+                             dropout=dropout, rngs=rngs, causal=False)
+            for _ in range(depth)
+        ])
+
+        self.norm = nnx.LayerNorm(dim, rngs=rngs)
+        self.head = nnx.Linear(dim, num_classes, rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        b = x.shape[0]
+        tokens = self.patch_embed(x)                       # (B, num_patches, dim)
+
+        # Prepend the CLS token to every example.
+        cls = jnp.broadcast_to(self.cls_token[...], (b, 1, tokens.shape[-1]))
+        tokens = jnp.concatenate([cls, tokens], axis=1)    # (B, num_patches+1, dim)
+
+        # Add learned positional embeddings (broadcast over the batch).
+        tokens = tokens + self.pos_embed[...]
+
+        for block in self.blocks:
+            tokens = block(tokens, train=train)            # global attention every layer
+
+        tokens = self.norm(tokens)
+        cls_out = tokens[:, 0]                             # (B, dim) — the CLS token
+        return self.head(cls_out)                         # (B, num_classes) logits
+```
+
+The shapes flow like this:
+
+```
+x            (B, 28, 28, 1)
+PatchEmbed   (B, 16, 64)     # 16 non-overlapping 7x7 patches -> dim 64
++ CLS token  (B, 17, 64)     # prepend one learned token
++ pos embed  (B, 17, 64)     # learned position per token
+encoder x4   (B, 17, 64)     # every token attends to all 17
+CLS -> head  (B, 10)         # classify from token 0
+```
+
+Instantiate it with an explicit `nnx.Rngs` and pair it with AdamW:
+
+```python
+model = ViT(num_classes=10, dim=64, depth=4, num_heads=4, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adamw(1e-3), wrt=nnx.Param)
+```
+
+## The training step
+
+This is the standard NNX pattern: a `loss_fn` closed over the model, `nnx.value_and_grad` with `has_aux=True`, then `optimizer.update`. We return the batch accuracy as a lightweight metric.
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        logits = model(batch["x"], train=True)              # (B, num_classes)
+        loss = compute_cross_entropy_loss(logits, batch["y"])
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    accuracy = compute_accuracy(logits, batch["y"])
+    return loss, accuracy
+```
+
+## Results / What to Expect
+
+The script defaults to tiny, offline **synthetic** data (no downloads): each class lights up a distinct 7×7 patch cell of the 4×4 grid, plus Gaussian noise. That gives a clean per-patch signal a ViT can learn on CPU in seconds. Loss falls and accuracy rises steadily:
+
+```console
+$ python vision/vit.py
+Vision Transformer on synthetic data
+  epochs=20 batch=64
+  dataset: images (512, 28, 28, 1), labels (512,)
+  epoch  1/20 | steps    8 | loss 2.5321 | acc 0.117
+  epoch  5/20 | steps   40 | loss 2.2699 | acc 0.150
+  epoch 10/20 | steps   80 | loss 2.0057 | acc 0.281
+  epoch 15/20 | steps  120 | loss 1.1706 | acc 0.605
+  epoch 20/20 | steps  160 | loss 0.5468 | acc 0.852
+Done. Every patch token attends to every other from the first layer — ...
+```
+
+On a single fixed batch the model is much faster — 40 steps take the loss from ~2.79 to ~0.39 and accuracy from ~0.12 to ~0.97 (this is what the verification harness checks). Point the script at real MNIST with `SYNTHETIC=0` (requires `tensorflow-datasets`).
+
+**Honest caveat on data-hunger.** A ViT has none of a CNN's built-in inductive biases — no locality, no translation equivariance. It must *learn* that neighboring patches are related, which takes more data and regularization. On small datasets a plain ViT typically **underperforms a comparable CNN/ResNet**; the transformer only pulls ahead at scale (large datasets or pretraining), or with heavy augmentation and distillation (see DeiT). Reach for a ViT when you have data or a pretrained checkpoint, not as a drop-in win on a few thousand images.
+
+## Common Pitfalls
+
+❌ **Storing the encoder blocks in a plain Python `list`.**
+✅ Wrap them in `nnx.List([...])` — on Flax 0.12 a bare list is not tracked as a pytree and training crashes.
+
+❌ **Forgetting positional embeddings.** Self-attention is permutation-invariant, so without them the model cannot tell a top-left patch from a bottom-right one.
+✅ Add a learned `pos_embed` of shape `(1, num_patches + 1, dim)` — sized for the patches *plus* the CLS token.
+
+❌ **Overlapping patches from the wrong conv config** (e.g. `padding="SAME"` or a stride smaller than the patch size).
+✅ Use `padding="VALID"` with `strides=(patch_size, patch_size)` so each patch is embedded exactly once.
+
+❌ **Sizing `pos_embed` to `num_patches` and then indexing `tokens[:, 0]` as the CLS token.** The shapes silently mismatch or you classify from a patch.
+✅ Prepend the CLS token *first*, size positional embeddings to `num_patches + 1`, and read token 0.
+
+❌ **Expecting the ViT to beat a CNN on a few thousand images.**
+✅ Use strong augmentation, distillation, or a pretrained backbone — or just use a CNN/ResNet when data is scarce.
+
+## Next steps
+
+- [U-Net Image Segmentation](/applications/vision/unet-segmentation) — go from whole-image labels to dense per-pixel predictions.
+- [GPT Architecture](/architectures/gpt) — the same transformer encoder machinery, made autoregressive with a causal mask.
+
+## Complete Example
+
+[`examples/vision/vit.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/vision/vit.py) — a runnable Vision Transformer with patch embedding, a learned CLS token and positional embeddings, synthetic-by-default data, and an MNIST switch.
+
+## References
+
+- Dosovitskiy et al., [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale](https://arxiv.org/abs/2010.11929) (2020) — the original ViT.
+- Vaswani et al., [Attention Is All You Need](https://arxiv.org/abs/1706.03762) (2017) — the transformer and scaled dot-product attention.
+- Touvron et al., [Training data-efficient image transformers & distillation through attention](https://arxiv.org/abs/2012.12877) (2020) — DeiT, making ViTs work on smaller data.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -93,6 +93,16 @@ Advanced patterns for cutting-edge research:
 
 [Explore Research Topics →](/research/advanced-techniques)
 
+### 🧩 Applications
+
+Small, self-contained implementations across model families and domains:
+- **Generative**: autoencoders, VAEs, GANs, and diffusion models
+- **Sequence**: recurrent networks (RNN/LSTM/GRU) and time series
+- **Scientific**: graph neural networks and physics-informed networks (PINNs)
+- **Adaptation**: parameter-efficient fine-tuning with LoRA
+
+[Explore Applications →](/applications)
+
 ## How to Use This Documentation
 
 ### If you're brand new:

--- a/website/docs/research/advanced-techniques.md
+++ b/website/docs/research/advanced-techniques.md
@@ -23,6 +23,7 @@ Learn powerful representations and shrink models without losing accuracy.
 
 - **[Contrastive Learning](/research/contrastive-learning)** — SimCLR self-supervised representation learning: the NT-Xent loss, augmentation pipeline, and linear-probe evaluation, all without labels.
 - **[Knowledge Distillation](/research/knowledge-distillation)** — Train small, fast student models from large teachers using temperature-scaled soft targets.
+- **[Metric Learning](/research/metric-learning)** — Learn embeddings where same-class inputs cluster, using Siamese networks and triplet loss with mining.
 
 ## Learning paradigms
 
@@ -38,6 +39,8 @@ Make models trustworthy and results reproducible.
 
 - **[Adversarial Training](/research/adversarial-training)** — Build robustness against adversarial examples using FGSM and the min-max robust optimization objective.
 - **[Experiment Reproducibility](/research/experiment-reproducibility)** — Deterministic, reproducible runs via explicit PRNG keys, config management, and XLA determinism.
+- **[Interpretability & Saliency](/research/interpretability)** — Explain predictions with vanilla-gradient saliency, Integrated Gradients, and Grad-CAM.
+- **[Uncertainty Estimation](/research/uncertainty)** — Quantify what the model doesn't know with MC-dropout and deep ensembles.
 
 ## Search and control
 

--- a/website/docs/research/interpretability.md
+++ b/website/docs/research/interpretability.md
@@ -1,0 +1,272 @@
+---
+sidebar_position: 12
+title: Saliency, Integrated Gradients & Grad-CAM in JAX
+description: "Attribute a CNN's predictions to input pixels in JAX and Flax NNX — vanilla gradient saliency, Integrated Gradients with a completeness check, and Grad-CAM."
+keywords: [interpretability, saliency maps, integrated gradients, Grad-CAM, JAX, Flax, NNX, attribution, explainability, feature attribution, XAI]
+---
+
+# Interpretability: Saliency, Integrated Gradients & Grad-CAM
+
+**Open the black box.** Take a trained CNN and ask *which pixels drove this prediction?* — with three classic, gradient-based attribution methods you can implement in a few lines of JAX.
+
+:::note Prerequisites
+A research-grade guide. You should be comfortable with a convolutional classifier first — see the [simple CNN](/basics/vision/simple-cnn) page. The core trick, differentiating a logit **with respect to the input**, is the same one used in [adversarial training](/research/adversarial-training), so that page is great background.
+:::
+
+:::tip What you'll learn
+- Compute **vanilla gradient saliency** as $|\partial \text{logit} / \partial x|$ with a single `jax.grad` call w.r.t. the input
+- Implement **Integrated Gradients** along a baseline path and verify the **completeness axiom** numerically
+- Build a simple **Grad-CAM** by differentiating a logit w.r.t. a convolutional feature map
+- Understand why a fully-convolutional + Global-Average-Pool head is the natural setting for Grad-CAM
+- Recognise the failure modes: gradient saturation, noisy maps, and degenerate (all-zero) heatmaps
+:::
+
+:::info Example Code
+See the full implementation: [`examples/advanced/interpretability.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/advanced/interpretability.py)
+:::
+
+## Why Interpretability?
+
+A model that predicts *"plus sign"* is only trustworthy if it does so **for the right reasons**. Attribution methods answer a concrete question: how much did each input feature contribute to a particular output? For an image classifier $f$ with class score $f_c$, an attribution assigns a value to every input pixel $x_i$, producing a heatmap you can overlay on the image.
+
+The three methods below trade off along a familiar axis:
+
+- **Vanilla saliency** — one gradient, instant, but noisy and prone to *saturation*.
+- **Integrated Gradients** — averages gradients along a path; satisfies clean axioms at the cost of many forward passes.
+- **Grad-CAM** — coarse but robust; uses gradients at a *feature map* rather than the raw input.
+
+All three are *post-hoc*: they explain an already-trained network without changing it.
+
+## The Model
+
+We need a CNN that exposes its **last convolutional feature map** so Grad-CAM can hook into it. We split the forward pass into `features()` (input → feature map $A$) and `classify_from_features()` (feature map → logits). The classifier head uses **Global Average Pooling**, which keeps the feature extractor fully convolutional — exactly what Grad-CAM assumes.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+
+class SaliencyCNN(nnx.Module):
+    """A tiny CNN that exposes its last conv feature map."""
+
+    def __init__(self, num_classes: int = 3, *, rngs: nnx.Rngs):
+        self.conv1 = nnx.Conv(1, 16, kernel_size=(3, 3), rngs=rngs)
+        self.conv2 = nnx.Conv(16, 32, kernel_size=(3, 3), rngs=rngs)
+        self.fc1 = nnx.Linear(32, 64, rngs=rngs)
+        self.fc2 = nnx.Linear(64, num_classes, rngs=rngs)
+
+    def features(self, x):
+        """Input -> last conv feature map A (before the classifier head)."""
+        x = nnx.relu(self.conv1(x))
+        x = nnx.max_pool(x, window_shape=(2, 2), strides=(2, 2))   # 28 -> 14
+        x = nnx.relu(self.conv2(x))                                # (B, 14, 14, 32)
+        return x
+
+    def classify_from_features(self, feat):
+        """Feature map A -> class logits via Global Average Pooling + MLP."""
+        pooled = jnp.mean(feat, axis=(1, 2))          # GAP over space -> (B, 32)
+        h = nnx.relu(self.fc1(pooled))
+        return self.fc2(h)
+
+    def __call__(self, x, train: bool = False):
+        return self.classify_from_features(self.features(x))
+```
+
+We train this on a **self-contained synthetic dataset**: each 28×28 image contains one of three shapes — a filled disk, a square outline, or a plus — drawn at a *random* location. Because the class depends on the shape, not its position, a GAP-head CNN can classify it, and the shape's pixels are exactly what a good attribution map should recover.
+
+## 1. Vanilla Gradient Saliency
+
+The simplest attribution: how much does the class score change if we nudge each pixel? That is just the magnitude of the gradient of the target logit with respect to the input (Simonyan et al., 2013):
+
+$$
+S_i(x) = \left| \frac{\partial f_c(x)}{\partial x_i} \right|
+$$
+
+In JAX, gradients w.r.t. the input are no harder than gradients w.r.t. parameters — you differentiate a function of `x` while the model is captured in the closure:
+
+```python
+def vanilla_saliency(model, x, target: int):
+    """Vanilla gradient saliency: |d logit_target / d input|.
+
+    x is a single image with a batch dim, shape (1, 28, 28, 1). The returned
+    saliency map has the SAME shape as the input.
+    """
+    def logit_fn(inp):
+        return model(inp)[0, target]              # scalar target logit
+    grad = jax.grad(logit_fn)(x)                  # d logit / d x, shape == x
+    return jnp.abs(grad)
+```
+
+**The catch: saturation.** Once a feature strongly activates the correct class, its gradient often *flattens to zero* — the network is already confident, so nudging that pixel barely moves the logit. Vanilla saliency then assigns near-zero importance to the very pixels that matter. Integrated Gradients fixes exactly this.
+
+## 2. Integrated Gradients
+
+Integrated Gradients (Sundararajan et al., 2017) accumulates gradients along a straight-line path from an information-less **baseline** $x'$ (here, a black image) to the actual input $x$. For pixel $i$:
+
+$$
+IG_i = (x_i - x'_i)\int_0^1 \frac{\partial f}{\partial x_i}\big(x' + \alpha (x - x')\big)\, d\alpha
+$$
+
+By walking from the baseline to the input, IG sees the gradient *before* the network saturates, so it no longer misses confident features. We approximate the integral with a midpoint Riemann sum and vectorise the path with `jax.vmap`:
+
+```python
+def integrated_gradients(model, x, target: int, baseline=None, steps: int = 256):
+    if baseline is None:
+        baseline = jnp.zeros_like(x)              # black-image baseline
+
+    def logit_fn(inp):
+        return model(inp)[0, target]
+    grad_fn = jax.grad(logit_fn)
+
+    # Midpoint rule: alphas at the centre of each of `steps` sub-intervals.
+    alphas = (jnp.arange(steps) + 0.5) / steps
+    interp = baseline + alphas[:, None, None, None, None] * (x - baseline)
+    grads = jax.vmap(grad_fn)(interp)             # gradient at each point on the path
+    avg_grads = grads.mean(axis=0)                # approximates the path integral
+    return (x - baseline) * avg_grads
+```
+
+### The Completeness Axiom
+
+IG's headline property is **completeness**: the attributions sum exactly to the difference in output between the input and the baseline.
+
+$$
+\sum_i IG_i = f_c(x) - f_c(x')
+$$
+
+This is a great built-in test — if your implementation is correct, the two sides match. Our example checks it directly:
+
+```python
+def completeness_gap(model, x, target: int, ig, baseline=None):
+    """Return (IG.sum(), f(x) - f(baseline)) for the completeness axiom."""
+    if baseline is None:
+        baseline = jnp.zeros_like(x)
+    lhs = float(jnp.sum(ig))
+    rhs = float(model(x)[0, target] - model(baseline)[0, target])
+    return lhs, rhs
+```
+
+Because a ReLU network is piecewise-linear, the path integral is essentially exact — the two sides agree to a relative error of $\sim 10^{-4}$ with a few hundred steps. If your gap is large, you almost always just need **more integration steps**.
+
+## 3. Grad-CAM
+
+Grad-CAM (Selvaraju et al., 2017) produces a *class-discriminative localisation map* by looking at the gradient flowing into the last convolutional feature map $A \in \mathbb{R}^{h\times w\times K}$, rather than the raw pixels. First, global-average-pool the gradients to get one importance weight per channel:
+
+$$
+\alpha_k^c = \frac{1}{h\,w}\sum_{i}\sum_{j} \frac{\partial f_c}{\partial A^k_{ij}}
+$$
+
+Then take a ReLU-ed weighted combination of the feature maps (ReLU keeps only evidence *for* the class):
+
+$$
+L^c_{\text{Grad-CAM}} = \mathrm{ReLU}\!\left(\sum_k \alpha_k^c\, A^k\right)
+$$
+
+The `features()` / `classify_from_features()` split lets us differentiate the logit w.r.t. the feature map, then upsample the coarse map back to input resolution:
+
+```python
+def grad_cam(model, x, target: int):
+    feat = model.features(x)                      # (1, 14, 14, K)
+
+    def logit_fn(f):
+        return model.classify_from_features(f)[0, target]
+    grads = jax.grad(logit_fn)(feat)              # d logit / d A
+
+    weights = grads.mean(axis=(1, 2), keepdims=True)          # (1, 1, 1, K) = alpha_k
+    cam = nnx.relu(jnp.sum(weights * feat, axis=-1))          # (1, 14, 14)
+    cam = cam / (cam.max() + 1e-8)                            # normalise to [0, 1]
+    cam = jax.image.resize(cam, (cam.shape[0], x.shape[1], x.shape[2]),
+                           method='bilinear')                 # -> (1, 28, 28)
+    return cam
+```
+
+## Training Step
+
+Attribution is only meaningful once the network has actually learned the task, so we first train the classifier with an ordinary supervised step:
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    """One supervised gradient step (standard classification)."""
+    def loss_fn(model):
+        logits = model(batch['x'], train=True)
+        loss = compute_cross_entropy_loss(logits, batch['y'])
+        return loss, logits
+
+    (loss, logits), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, logits
+```
+
+Set up the model and optimizer with the modern NNX API:
+
+```python
+model = SaliencyCNN(num_classes=3, rngs=nnx.Rngs(0))
+optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+```
+
+## Results / What to Expect
+
+Running the example trains the CNN to 100% accuracy on the synthetic shapes in ~160 steps, then attributes one test image. The key checks are the **attribution properties**, not a decreasing loss:
+
+```
+Interpretability: saliency / integrated gradients / Grad-CAM
+  epochs=10 batch=64 n=1024 classes=3 ig_steps=256 shapes=('disk', 'square-ring', 'plus')
+  dataset: (1024, 28, 28, 1)  labels in [0, 2]
+  epoch  8/10 | steps  128 | loss 0.4168 | acc 1.000
+  epoch 10/10 | steps  160 | loss 0.2108 | acc 1.000
+
+Explaining image 0 (true shape 'square-ring', predicted 'square-ring')
+  saliency map shape:   (1, 28, 28, 1)  (== input (1, 28, 28, 1))
+  integrated gradients: shape (1, 28, 28, 1)
+    completeness: IG.sum()=+6.877846  f(x)-f(baseline)=+6.875711  |gap|=2.13e-03  rel=3.10e-04
+  grad-cam heatmap:     shape (1, 28, 28)  range [0.00, 0.95]
+```
+
+Three properties to verify:
+
+- **Saliency map shape equals the input shape** — one importance value per input element.
+- **Completeness holds**: `IG.sum()` ≈ `f(x) − f(baseline)` (here to a relative error of `3.1e-04`).
+- **Grad-CAM is non-degenerate**: the heatmap spans `[0, 0.95]` rather than collapsing to all zeros.
+
+## Common Pitfalls
+
+**1. Gradient saturation makes vanilla saliency blank**
+❌ Rely on raw gradients for a confident model → the most important pixels get ≈0 importance.
+✅ Use Integrated Gradients (or SmoothGrad) to integrate over less-saturated regions of the path.
+
+**2. Integrated Gradients with too few steps**
+❌ Use a handful of steps and see `IG.sum()` drift away from `f(x) − f(baseline)`.
+✅ Increase `steps` (128–256 is plenty here) and check the completeness gap as a correctness test.
+
+**3. A meaningless baseline**
+❌ Pick a baseline that isn't information-less (e.g. a real image) and misread the attributions.
+✅ Use a black image (or an average/blurred input) so IG measures contribution *relative to "nothing"*.
+
+**4. Grad-CAM heatmap collapses to all zeros**
+❌ Global-average-pool the gradients over a head that uses *spatial position* (e.g. flatten → dense) — the positive and negative weights cancel and ReLU zeros the map.
+✅ Attribute a fully-convolutional extractor with a **GAP head**, the setting Grad-CAM was designed for.
+
+**5. Explaining an untrained model**
+❌ Compute attributions before the network learns the task → you visualise noise.
+✅ Train to good accuracy first; the example asserts accuracy > 0.9 before attributing.
+
+## Next steps
+
+- [Uncertainty Estimation](/research/uncertainty) — go beyond "which pixels?" to "how confident?" with calibrated predictions.
+- [Adversarial Training](/research/adversarial-training) — the same input-gradient trick, used to *attack* and harden models.
+- Back to the [Research hub](/research/advanced-techniques).
+
+## Complete Example
+
+**Saliency, Integrated Gradients & Grad-CAM implementation:**
+- [`examples/advanced/interpretability.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/advanced/interpretability.py) — trains a tiny CNN on synthetic shapes, then computes all three attribution maps with a completeness check.
+
+## References
+
+- **Saliency Maps**: [Deep Inside Convolutional Networks: Visualising Image Classification Models and Saliency Maps](https://arxiv.org/abs/1312.6034) (Simonyan et al., 2013)
+- **Integrated Gradients**: [Axiomatic Attribution for Deep Networks](https://arxiv.org/abs/1703.01365) (Sundararajan et al., ICML 2017)
+- **Grad-CAM**: [Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization](https://arxiv.org/abs/1610.02391) (Selvaraju et al., ICCV 2017)
+- **CAM**: [Learning Deep Features for Discriminative Localization](https://arxiv.org/abs/1512.04150) (Zhou et al., CVPR 2016)
+- **SmoothGrad**: [SmoothGrad: removing noise by adding noise](https://arxiv.org/abs/1706.03825) (Smilkov et al., 2017)

--- a/website/docs/research/metric-learning.md
+++ b/website/docs/research/metric-learning.md
@@ -1,0 +1,280 @@
+---
+sidebar_position: 11
+title: Metric Learning with Siamese Nets & Triplet Loss
+description: "Learn embeddings where same-class inputs cluster and different classes separate — Siamese networks, triplet loss, and in-batch hard mining in Flax NNX."
+keywords:
+  - metric learning
+  - triplet loss
+  - Siamese network
+  - JAX
+  - Flax
+  - NNX
+  - embedding
+  - hard negative mining
+  - FaceNet
+  - representation learning
+  - verification
+image: img/docusaurus-social-card.jpg
+---
+
+# Metric Learning with Siamese Networks & Triplet Loss
+
+**Teach a network a distance, not a label.** Instead of predicting a class, a metric-learning model maps inputs to an embedding space where same-class points are close and different-class points are far — perfect for verification, retrieval, clustering, and open-set recognition.
+
+:::note Prerequisites
+This is a research-grade guide. It builds directly on [contrastive learning](/research/contrastive-learning) — read that first if the idea of "pull positives together, push negatives apart" is new. The embedding backbone is a plain MLP here, but the same recipe drops onto the [simple CNN](/basics/vision/simple-cnn) for images.
+:::
+
+:::tip What you'll learn
+- Why metric learning optimizes a **distance** between embeddings instead of a classification logit
+- The **triplet loss** and the role of the **margin**, derived and implemented in ~10 lines of JAX
+- **In-batch hard mining** — how to build informative triplets on the fly instead of wasting compute on easy ones
+- How **L2-normalized embeddings** put every point on the unit hypersphere so the margin has a consistent scale
+- How supervised metric learning differs from self-supervised SimCLR (labels vs augmentation views)
+:::
+
+:::info Example Code
+See the full implementation: [`examples/advanced/metric_learning.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/advanced/metric_learning.py)
+:::
+
+## Why Metric Learning?
+
+A classifier answers "which of these $N$ fixed classes is this?" But many problems don't fit that mold:
+
+- **Verification**: are these two signatures / faces / fingerprints the *same identity*? (You may never have seen that identity at training time.)
+- **Retrieval**: given a query, rank a gallery by similarity.
+- **Few-shot / open-set**: new classes appear after training, so a fixed softmax head is useless.
+
+Metric learning sidesteps the fixed label set. It trains an **embedding function** $f_\theta: x \mapsto z \in \mathbb{R}^d$ so that a simple geometric distance encodes semantic similarity:
+
+$$
+d(x_a, x_b) = \lVert f_\theta(x_a) - f_\theta(x_b) \rVert_2^2 \quad \text{is small} \iff x_a, x_b \text{ are the same class.}
+$$
+
+At inference you compare embeddings with a distance — no retraining needed when a new class shows up.
+
+### A Siamese network is just weight sharing
+
+The classic picture is two (or three) identical towers with **shared weights**, one per input. In NNX that sharing is automatic: you define *one* module and apply it to every input. There is no second copy to keep in sync.
+
+## The Triplet Loss
+
+A triplet is $(a, p, n)$: an **anchor** $a$, a **positive** $p$ of the *same* class, and a **negative** $n$ of a *different* class. We want the anchor closer to the positive than to the negative, by at least a margin $m$:
+
+$$
+d(a, p) + m \le d(a, n).
+$$
+
+Turning that constraint into a hinge loss gives the **triplet loss**:
+
+$$
+\mathcal{L}(a, p, n) = \max\!\big(0,\; d(a, p) - d(a, n) + m \big).
+$$
+
+- If the constraint is already satisfied ($d(a,n) - d(a,p) \ge m$), the loss is exactly $0$ and produces **no gradient** — the triplet is "easy".
+- The **margin** $m$ sets how much farther the negative must be than the positive. Too small and embeddings collapse; too large and training never reaches zero loss.
+
+Because we L2-normalize embeddings onto the unit sphere, squared distances live in $[0, 4]$, so a margin around $0.2$ is a sensible scale.
+
+## The Embedding Network
+
+One shared network, applied to every input, with an L2 normalization on the output:
+
+```python
+from shared.models import MLP  # (B, in) -> (B, out)
+
+class EmbeddingNet(nnx.Module):
+    """Shared-weight embedding network: input vector -> L2-normalized embedding."""
+
+    def __init__(self, in_features: int, hidden: int, embed_dim: int,
+                 *, rngs: nnx.Rngs, depth: int = 2):
+        self.backbone = MLP(in_features, hidden, embed_dim, n_layers=depth,
+                            rngs=rngs, activation="relu")
+
+    def embed(self, x):
+        z = self.backbone(x)
+        return z / (jnp.linalg.norm(z, axis=-1, keepdims=True) + 1e-8)
+
+    def __call__(self, x, train: bool = False):
+        return self.embed(x)
+```
+
+Normalizing to unit norm is what makes the margin meaningful: without it the network can trivially shrink or inflate all distances and game the loss. Swap `MLP` for a small CNN and the exact same training code works on images.
+
+## In-Batch Hard Mining
+
+Random triplets are mostly *easy* — the negative is already far, the loss is $0$, and you learn nothing. The fix is **mining**: build hard triplets from the examples already in the batch. This example uses **batch-hard** mining (Hermans et al. 2017): for every anchor, pick the *farthest* positive and the *closest* negative in the batch.
+
+First, a pairwise squared-distance matrix:
+
+```python
+def pairwise_sq_dist(z):
+    """Squared Euclidean distance matrix D[i, j] = ||z_i - z_j||^2, shape (B, B)."""
+    sq = jnp.sum(z * z, axis=1)
+    d = sq[:, None] + sq[None, :] - 2.0 * (z @ z.T)
+    return jnp.maximum(d, 0.0)   # clip tiny negatives from round-off
+```
+
+Then mine the hardest positive/negative per anchor using label masks:
+
+```python
+def batch_hard_triplet_loss(z, labels, margin: float = 0.2):
+    B = z.shape[0]
+    D = pairwise_sq_dist(z)
+
+    same = labels[:, None] == labels[None, :]
+    eye = jnp.eye(B, dtype=bool)
+    pos_mask = same & ~eye          # same class, excluding the anchor itself
+    neg_mask = ~same                # different class
+
+    # Hardest positive: largest distance among same-class examples.
+    hardest_pos = jnp.max(jnp.where(pos_mask, D, -jnp.inf), axis=1)
+    # Hardest negative: smallest distance among different-class examples.
+    hardest_neg = jnp.min(jnp.where(neg_mask, D, jnp.inf), axis=1)
+
+    losses = jax.nn.relu(hardest_pos - hardest_neg + margin)
+    frac_active = jnp.mean((losses > 0).astype(jnp.float32))
+    return jnp.mean(losses), frac_active
+```
+
+The `frac_active` telemetry — the fraction of anchors with nonzero loss — is worth watching: if it collapses to $0$ too early, the batch has no hard examples left and learning stalls.
+
+:::tip Semi-hard vs batch-hard
+**Batch-hard** always takes the closest negative. **Semi-hard** (the original FaceNet strategy) instead picks a negative that is farther than the positive but still inside the margin: $d(a,p) < d(a,n) < d(a,p)+m$. It avoids a handful of pathological hardest negatives and can be more stable early in training. You can implement it by masking `D` to that band before the `min`.
+:::
+
+### Balanced "PK" batches make mining possible
+
+Mining needs every anchor to *have* both positives and negatives in the batch. Random shuffling doesn't guarantee that, so sample **P classes × K examples each**:
+
+```python
+def make_pk_batch(X, Y, class_to_idx, P: int, K: int, rng):
+    """Sample a balanced batch: P classes, K examples each (batch = P*K)."""
+    classes = rng.choice(list(class_to_idx.keys()), size=P, replace=False)
+    idxs = []
+    for c in classes:
+        pool = class_to_idx[int(c)]
+        pick = rng.choice(pool, size=K, replace=len(pool) < K)
+        idxs.extend(pick.tolist())
+    idxs = np.array(idxs)
+    return {'x': jnp.asarray(X[idxs]), 'y': jnp.asarray(Y[idxs])}
+```
+
+## The Training Step
+
+Standard NNX: differentiate the loss, update in place. The embeddings and mining are computed inside `loss_fn` so gradients flow through the whole batch of triplets.
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch, margin: float = 0.2):
+    """One gradient step of triplet-loss metric learning."""
+    def loss_fn(model):
+        z = model.embed(batch['x'])                       # (B, embed_dim), unit norm
+        loss, frac_active = batch_hard_triplet_loss(z, batch['y'], margin)
+        return loss, frac_active
+
+    (loss, frac_active), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, frac_active
+```
+
+## Measuring Progress: Verification Accuracy
+
+Triplet loss alone is a noisy progress signal — it depends on which hard triplets happen to land in a batch. A cleaner **verification** metric asks a ranking question directly: for each anchor, is its *mean same-class distance* smaller than its *mean different-class distance*?
+
+```python
+def verification_accuracy(z, labels):
+    B = z.shape[0]
+    D = pairwise_sq_dist(z)
+    same = labels[:, None] == labels[None, :]
+    eye = jnp.eye(B, dtype=bool)
+    pos_mask = (same & ~eye).astype(jnp.float32)
+    neg_mask = (~same).astype(jnp.float32)
+
+    mean_pos = (D * pos_mask).sum(1) / jnp.maximum(pos_mask.sum(1), 1.0)
+    mean_neg = (D * neg_mask).sum(1) / jnp.maximum(neg_mask.sum(1), 1.0)
+
+    acc = jnp.mean((mean_pos < mean_neg).astype(jnp.float32))
+    return acc, mean_pos.mean(), mean_neg.mean()
+```
+
+This starts near $0.5$ (random) and climbs toward $1.0$ as the classes separate — a much more stable curve to watch than the raw loss.
+
+## Metric Learning vs SimCLR
+
+Metric learning and [SimCLR contrastive learning](/research/contrastive-learning) share the "pull together / push apart" intuition, but they differ in where the *supervision* comes from:
+
+| | Metric learning (this page) | SimCLR |
+|---|---|---|
+| Supervision | **Labels** define positives/negatives | **Augmentations** define positives |
+| Positive pair | Two examples of the *same class* | Two augmented views of the *same image* |
+| Negatives | Different-class examples | All other images in the batch |
+| Loss | Triplet / margin loss | NT-Xent (softmax over similarities) |
+| Needs labels? | **Yes** | No (self-supervised) |
+
+In short: SimCLR *invents* positives with augmentation because it has no labels; metric learning *has* labels and uses them to define what "same" means.
+
+## Results / What to Expect
+
+By default the script runs fully offline on synthetic **class-structured vectors** (10 overlapping Gaussian blobs), so it trains in seconds on CPU. Set `SYNTHETIC=0` to run on real MNIST (flattened) instead.
+
+```bash
+python examples/advanced/metric_learning.py
+```
+
+```
+Metric learning (Siamese + triplet loss) on synthetic class-structured vectors
+  data: X=(800, 48) classes=10 | in_features=48
+  epochs=8 batch=64 (P=8 classes x K=8) embed_dim=32 margin=0.2
+  model: EmbeddingNet with 26912 parameters
+
+  epoch  1/8 | step   12 | triplet 0.6823 | active 1.00 | ver_acc 0.885 | d+ 0.204 d- 0.247
+  epoch  2/8 | step   24 | triplet 0.3083 | active 1.00 | ver_acc 0.969 | d+ 0.083 d- 0.106
+  epoch  4/8 | step   48 | triplet 0.2314 | active 1.00 | ver_acc 0.979 | d+ 0.038 d- 0.050
+  epoch  6/8 | step   72 | triplet 0.2199 | active 1.00 | ver_acc 0.990 | d+ 0.026 d- 0.035
+  epoch  8/8 | step   96 | triplet 0.2144 | active 1.00 | ver_acc 0.990 | d+ 0.020 d- 0.027
+
+Done. The embedding pulls same-class inputs together and pushes different-class inputs apart (d+ < d-).
+```
+
+The **triplet loss falls** (0.68 → 0.21), the mean same-class distance `d+` stays below the mean different-class distance `d-`, and **verification accuracy rises** toward 0.99. The loss plateaus near the margin because batch-hard mining keeps surfacing the toughest remaining triplets — that residual is expected, not a bug.
+
+## Common Pitfalls
+
+**1. Forgetting to normalize embeddings**
+❌ The network cheats by scaling all distances, and the margin loses meaning.
+✅ L2-normalize the output (unit hypersphere) so the margin has a fixed, interpretable scale.
+
+**2. Random triplets instead of mining**
+❌ Most random triplets are already easy → loss $\approx 0$ → no gradient → glacial training.
+✅ Mine hard (or semi-hard) triplets *within the batch* so every step has signal.
+
+**3. Unbalanced batches**
+❌ A shuffled batch may give an anchor zero same-class peers, so mining has no positive.
+✅ Sample balanced **P classes × K examples** batches so positives and negatives always exist.
+
+**4. Margin set wrong**
+❌ Too large → loss never reaches zero and embeddings never tighten; too small → representations collapse to a point.
+✅ Start around $m = 0.2$ for unit-norm embeddings and tune while watching `frac_active`.
+
+**5. Judging progress by loss alone**
+❌ Batch-hard loss is noisy and plateaus near the margin, which looks like "stuck".
+✅ Track a **verification / retrieval** metric (positive pairs closer than negatives) as the real signal.
+
+## Next steps
+
+- [Contrastive Learning with SimCLR](/research/contrastive-learning) — the self-supervised cousin that invents positives from augmentations instead of labels.
+- [Advanced Techniques](/research/advanced-techniques) — more research-grade training recipes and the Research hub.
+- [Simple CNN](/basics/vision/simple-cnn) — swap the MLP backbone for a conv net to do metric learning on images.
+
+## Complete Example
+
+**Siamese + triplet-loss metric learning:**
+- [`examples/advanced/metric_learning.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/advanced/metric_learning.py) — shared-weight embedding network, batch-hard triplet loss, balanced PK sampling, and a verification metric. Runs offline on synthetic data by default; `SYNTHETIC=0` switches to MNIST.
+
+## References
+
+- **FaceNet**: [A Unified Embedding for Face Recognition and Clustering](https://arxiv.org/abs/1503.03832) (Schroff et al., CVPR 2015) — introduced the triplet loss with semi-hard mining.
+- **In Defense of the Triplet Loss**: [In Defense of the Triplet Loss for Person Re-Identification](https://arxiv.org/abs/1703.07737) (Hermans et al., 2017) — the batch-hard mining strategy used here.
+- **Contrastive loss (Siamese)**: [Dimensionality Reduction by Learning an Invariant Mapping](https://ieeexplore.ieee.org/document/1640964) (Hadsell, Chopra & LeCun, CVPR 2006) — the original margin-based pairwise loss.
+- **Sampling Matters**: [Sampling Matters in Deep Embedding Learning](https://arxiv.org/abs/1706.07567) (Wu et al., ICCV 2017) — why negative mining/sampling drives embedding quality.

--- a/website/docs/research/uncertainty.md
+++ b/website/docs/research/uncertainty.md
@@ -1,0 +1,252 @@
+---
+sidebar_position: 13
+title: "Uncertainty Estimation: MC-Dropout & Ensembles"
+description: "Estimate predictive uncertainty in JAX and Flax NNX — MC-Dropout, deep ensembles via nnx.vmap, and the aleatoric/epistemic variance decomposition on a heteroscedastic task."
+keywords: [uncertainty estimation, MC-Dropout, deep ensembles, JAX, Flax, NNX, aleatoric, epistemic, Bayesian deep learning, predictive variance, heteroscedastic regression]
+---
+
+# Uncertainty Estimation
+
+**A prediction without a confidence is only half an answer.** This guide builds two practical uncertainty estimators in Flax NNX — Monte-Carlo Dropout and deep ensembles — and decomposes their predictions into *aleatoric* (data noise) and *epistemic* (model ignorance) parts on a 1D heteroscedastic regression task.
+
+:::note Prerequisites
+A research-grade guide. You should be comfortable with [training best practices](/basics/training-best-practices) (dropout, optimizers, NLL losses). It pairs naturally with [adversarial training](/research/adversarial-training): both ask what a model does when the input drifts away from its training distribution.
+:::
+
+:::tip What you'll learn
+- Why a point prediction is not enough, and how to split predictive variance into **aleatoric + epistemic** parts
+- **MC-Dropout**: keep dropout ON at test time and run `T` stochastic forward passes to approximate a Bayesian posterior
+- **Deep ensembles**: train `M` networks at once with `nnx.vmap` and aggregate their disagreement
+- How to train a Gaussian mean+variance head with the **heteroscedastic NLL** loss
+- Why uncertainty *grows* in gaps between clusters and in the extrapolation tails
+:::
+
+:::info Example Code
+See the full implementation: [`examples/advanced/uncertainty.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/advanced/uncertainty.py)
+:::
+
+## Why Uncertainty?
+
+A standard regressor outputs a single number $\hat y = f_\theta(x)$. But two very different situations produce the same point estimate:
+
+- The input is noisy but *familiar* — the model has seen lots of nearby data (irreducible **aleatoric** noise).
+- The input is far from anything in the training set — the model is *guessing* (**epistemic** uncertainty).
+
+Distinguishing these is essential for active learning, out-of-distribution detection, safe control, and Bayesian optimization. The trick is to make the model produce a **distribution** over outputs, then measure its spread.
+
+## The Predictive Variance Decomposition
+
+Let each network define a Gaussian per input, $p(y \mid x, \theta) = \mathcal{N}\big(\mu_\theta(x),\, \sigma_\theta^2(x)\big)$, where the variance head $\sigma_\theta^2(x)$ captures input-dependent (heteroscedastic) noise. Averaging over an approximate posterior $\theta \sim q(\theta)$ — realized as $T$ dropout masks or $M$ ensemble members — the **law of total variance** splits the predictive variance cleanly:
+
+$$
+\underbrace{\operatorname{Var}(y \mid x)}_{\text{total}}
+= \underbrace{\mathbb{E}_{\theta}\!\left[\sigma_\theta^2(x)\right]}_{\text{aleatoric}}
++ \underbrace{\operatorname{Var}_{\theta}\!\left(\mu_\theta(x)\right)}_{\text{epistemic}}
+$$
+
+With $K$ samples $\{(\mu_k, \sigma_k^2)\}_{k=1}^{K}$ (either $K=T$ MC passes or $K=M$ members), the Monte-Carlo estimates are:
+
+$$
+\bar\mu(x) = \frac{1}{K}\sum_{k} \mu_k(x),\qquad
+\underbrace{\frac{1}{K}\sum_{k} \sigma_k^2(x)}_{\text{aleatoric}},\qquad
+\underbrace{\frac{1}{K}\sum_{k} \big(\mu_k(x) - \bar\mu(x)\big)^2}_{\text{epistemic}}
+$$
+
+The key intuition: **aleatoric** noise is what the variance heads report on average, while **epistemic** uncertainty is how much the *means* disagree. Where data is dense, the means agree and epistemic uncertainty collapses; in gaps and tails, they fan out.
+
+## The Model: a Gaussian MLP with Dropout
+
+The network predicts a mean and a log-variance. Dropout layers double as the source of MC stochasticity. We clamp `log_var` for numerical stability.
+
+```python
+from flax import nnx
+import jax.numpy as jnp
+
+class GaussianMLP(nnx.Module):
+    """MLP that outputs (mu, log_var) with dropout for MC sampling."""
+
+    def __init__(self, in_features=1, hidden=64, dropout_rate=0.1, *, rngs: nnx.Rngs):
+        self.l1 = nnx.Linear(in_features, hidden, rngs=rngs)
+        self.l2 = nnx.Linear(hidden, hidden, rngs=rngs)
+        self.drop = nnx.Dropout(dropout_rate, rngs=rngs)
+        self.mu_head = nnx.Linear(hidden, 1, rngs=rngs)
+        self.logvar_head = nnx.Linear(hidden, 1, rngs=rngs)
+
+    def __call__(self, x, train: bool = False):
+        h = nnx.relu(self.l1(x))
+        h = self.drop(h, deterministic=not train)
+        h = nnx.relu(self.l2(h))
+        h = self.drop(h, deterministic=not train)
+        mu = self.mu_head(h)
+        log_var = jnp.clip(self.logvar_head(h), -6.0, 4.0)
+        return mu, log_var
+```
+
+### Heteroscedastic NLL loss
+
+Training the variance head with the Gaussian negative log-likelihood lets the model learn *where* the data is noisy, instead of assuming one global $\sigma$:
+
+$$
+\mathcal{L}(\theta) = \frac{1}{N}\sum_{i} \frac{1}{2}\left[\log \sigma_\theta^2(x_i) + \frac{(y_i - \mu_\theta(x_i))^2}{\sigma_\theta^2(x_i)}\right]
+$$
+
+```python
+def gaussian_nll(mu, log_var, y):
+    """Mean Gaussian negative log-likelihood (drops the constant term)."""
+    inv_var = jnp.exp(-log_var)
+    return 0.5 * jnp.mean(log_var + (y - mu) ** 2 * inv_var)
+```
+
+### Train step
+
+A standard NNX train step — `nnx.value_and_grad` with `has_aux=True`, then `optimizer.update(model, grads)`:
+
+```python
+@nnx.jit
+def train_step(model, optimizer, batch):
+    def loss_fn(model):
+        mu, log_var = model(batch["x"], train=True)
+        loss = gaussian_nll(mu, log_var, batch["y"])
+        return loss, mu
+
+    (loss, mu), grads = nnx.value_and_grad(loss_fn, has_aux=True)(model)
+    optimizer.update(model, grads)
+    return loss, mu
+```
+
+## Method 1: MC-Dropout
+
+Gal & Ghahramani showed that a network trained with dropout, *left on at test time*, approximates a deep Gaussian process posterior. Concretely: keep `train=True` at inference and run `T` forward passes. Each call advances the dropout RNG, so the `T` predictions differ — their spread is the epistemic signal.
+
+```python
+@nnx.jit
+def _mc_forward(model, x):
+    return model(x, train=True)  # dropout stays ACTIVE
+
+def mc_predict(model, x, n_samples=30):
+    mus, variances = [], []
+    for _ in range(n_samples):
+        mu, log_var = _mc_forward(model, x)
+        mus.append(mu)
+        variances.append(jnp.exp(log_var))
+    mus = jnp.stack(mus)            # (T, N, 1)
+    variances = jnp.stack(variances)
+    return {
+        "mean":      mus.mean(axis=0),
+        "aleatoric": variances.mean(axis=0),   # E[sigma^2]
+        "epistemic": mus.var(axis=0),          # Var(mu)
+        "total":     variances.mean(axis=0) + mus.var(axis=0),
+    }
+```
+
+## Method 2: Deep Ensembles via `nnx.vmap`
+
+Deep ensembles (Lakshminarayanan et al.) are embarrassingly simple and often *better calibrated* than fancier Bayesian methods: train `M` networks from different random inits and aggregate. In JAX we don't loop — we `vmap`. A single vmapped constructor builds all `M` members **and** their optimizers, and one vmapped step trains them together.
+
+```python
+import optax
+
+@nnx.vmap(in_axes=0, out_axes=0)
+def make_ensemble(key):
+    """Build one independently-initialized member + its optimizer per key."""
+    model = GaussianMLP(dropout_rate=0.1, rngs=nnx.Rngs(key))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+    return model, optimizer
+
+@nnx.vmap(in_axes=(0, 0, 0), out_axes=0)
+def ensemble_train_step(model, optimizer, batch):
+    def loss_fn(model):
+        mu, log_var = model(batch["x"], train=True)
+        return gaussian_nll(mu, log_var, batch["y"])
+    loss, grads = nnx.value_and_grad(loss_fn)(model)
+    optimizer.update(model, grads)
+    return loss
+```
+
+Each member is trained on its own **bootstrap resample** of the data (`in_axes=0` over a batch of shape `(M, N, 1)`), which adds diversity on top of the random inits. Aggregation reuses the same decomposition — only the averaging axis is now the model axis:
+
+```python
+@nnx.vmap(in_axes=(0, None), out_axes=0)
+def _ensemble_forward(model, x):
+    return model(x, train=False)   # deterministic; diversity comes from params
+
+def ensemble_predict(models, x):
+    mu, log_var = _ensemble_forward(models, x)   # each (M, N, 1)
+    variances = jnp.exp(log_var)
+    return {
+        "mean":      mu.mean(axis=0),
+        "aleatoric": variances.mean(axis=0),
+        "epistemic": mu.var(axis=0),
+        "total":     variances.mean(axis=0) + mu.var(axis=0),
+    }
+```
+
+Building the ensemble and its optimizers with `make_ensemble(jax.random.split(key, M))` returns pytrees with a leading `M` axis; `_ensemble_forward` maps over that axis (broadcasting the shared inputs with `in_axes=(0, None)`) to produce `(M, N, 1)` predictions.
+
+## Results / What to Expect
+
+Running the example (small CPU defaults: 120 training points in two clusters, a single MC-Dropout net for 500 steps, and a 5-member ensemble for 1000 steps) takes well under a minute:
+
+```console
+$ python advanced/uncertainty.py
+======================================================================
+UNCERTAINTY ESTIMATION: MC-Dropout + Deep Ensembles
+======================================================================
+Training points: 120 (two clusters, heteroscedastic noise)
+
+[1/2] Training a single MC-Dropout network...
+  step  100/500 | NLL 2.0752
+  step  200/500 | NLL 2.0067
+  step  300/500 | NLL 2.0034
+  step  400/500 | NLL 2.0042
+  step  500/500 | NLL 2.0025
+  MC-Dropout epistemic: in-cluster 0.27764 | away 0.72647
+
+[2/2] Training a deep ensemble of 5 networks (nnx.vmap)...
+  step  200/1000 | mean NLL 0.2462
+  step  400/1000 | mean NLL -0.1143
+  step  600/1000 | mean NLL -0.1560
+  step  800/1000 | mean NLL -0.2839
+  step 1000/1000 | mean NLL -0.3380
+  Ensemble epistemic:   in-cluster 0.02592 | away 0.12889
+
+======================================================================
+Uncertainty grows away from the training data for BOTH methods.
+Aleatoric captures data noise; epistemic captures model ignorance.
+======================================================================
+```
+
+The headline numbers are the `in-cluster` vs `away` **epistemic** uncertainty. For both methods, epistemic uncertainty is markedly larger away from the training clusters (in the middle gap and the extrapolation tails) than inside them — exactly the behavior we want. The ensemble's negative NLL means it fits the data likelihood tightly, while its epistemic variance still fans out where there is no data.
+
+## Common Pitfalls
+
+- ❌ Calling the model with `train=False` for MC-Dropout — dropout is disabled, every pass is identical, epistemic variance collapses to zero.
+  ✅ Use `train=True` at inference (`_mc_forward` above) so masks are resampled each pass.
+
+- ❌ Averaging over the wrong axis. Stacking `T` passes gives shape `(T, N, 1)`; taking `.var()` over everything mixes samples and data points.
+  ✅ Reduce over `axis=0` only: `mus.var(axis=0)` for epistemic, `variances.mean(axis=0)` for aleatoric.
+
+- ❌ Reporting `Var(mu)` as the *total* uncertainty. That drops the aleatoric term and under-estimates noise in high-noise regions.
+  ✅ Report `total = aleatoric + epistemic`, and keep the two components separate when you need to act on them.
+
+- ❌ Giving the vmapped constructor a defaulted scalar arg (e.g. `def make_ensemble(key, dropout_rate=0.1)`). `nnx.vmap(in_axes=0)` then tries to map a rank-0 value and crashes.
+  ✅ Keep only the mapped argument (`key`) in the signature; bake constants inside the function body.
+
+- ❌ Letting `log_var` run to `±∞`, producing `NaN` losses when `exp(-log_var)` overflows.
+  ✅ Clamp it (`jnp.clip(log_var, -6.0, 4.0)`) and train with the numerically stable NLL that uses `exp(-log_var)` rather than dividing by a variance.
+
+## Next steps
+
+- [Interpretability](/research/interpretability) — pair uncertainty maps with saliency to understand *why* a model is unsure.
+- [Advanced Techniques](/research/advanced-techniques) — more research-grade training patterns in Flax NNX.
+- [Adversarial Training](/research/adversarial-training) — the flip side: what a model does when inputs are pushed off-distribution on purpose.
+
+## Complete Example
+
+The full, runnable script — data generation, both methods, and the region-wise uncertainty report — lives at [`examples/advanced/uncertainty.py`](https://github.com/mlnomadpy/flaxdocs/tree/master/examples/advanced/uncertainty.py). Run it with `EPOCHS`, `BATCH`, `N_MODELS`, and `MC_SAMPLES` environment variables to scale it up.
+
+## References
+
+- [Dropout as a Bayesian Approximation: Representing Model Uncertainty in Deep Learning](https://arxiv.org/abs/1506.02142) (Gal & Ghahramani, 2015) — the MC-Dropout foundation.
+- [What Uncertainties Do We Need in Bayesian Deep Learning for Computer Vision?](https://arxiv.org/abs/1703.04977) (Kendall & Gal, 2017) — the aleatoric/epistemic decomposition used here.
+- [Simple and Scalable Predictive Uncertainty Estimation using Deep Ensembles](https://arxiv.org/abs/1612.01474) (Lakshminarayanan et al., 2016) — deep ensembles with Gaussian mean+variance heads.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -94,6 +94,7 @@ const sidebars: SidebarsConfig = {
             'applications/generative/vae',
             'applications/generative/gan',
             'applications/generative/diffusion',
+            'applications/generative/normalizing-flows',
           ],
         },
         {
@@ -102,6 +103,9 @@ const sidebars: SidebarsConfig = {
           items: [
             'applications/sequence/index',
             'applications/sequence/recurrent-networks',
+            'applications/sequence/seq2seq',
+            'applications/sequence/time-series',
+            'applications/sequence/word2vec',
           ],
         },
         {
@@ -111,6 +115,18 @@ const sidebars: SidebarsConfig = {
             'applications/scientific/index',
             'applications/scientific/graph-neural-networks',
             'applications/scientific/pinn',
+            'applications/scientific/neural-ode',
+            'applications/scientific/tabular',
+            'applications/scientific/mixture-of-experts',
+          ],
+        },
+        {
+          type: 'category',
+          label: '🖼️ Advanced Vision',
+          items: [
+            'applications/vision/index',
+            'applications/vision/vision-transformer',
+            'applications/vision/unet-segmentation',
           ],
         },
         {
@@ -119,6 +135,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'applications/adaptation/index',
             'applications/adaptation/lora-finetuning',
+            'applications/adaptation/clip',
           ],
         },
       ],
@@ -148,6 +165,9 @@ const sidebars: SidebarsConfig = {
         'research/knowledge-distillation',
         'research/meta-learning',
         'research/reinforcement-learning',
+        'research/metric-learning',
+        'research/interpretability',
+        'research/uncertainty',
       ],
     },
   ],

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -81,6 +81,50 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: '🧩 Applications',
+      collapsed: false,
+      items: [
+        'applications/index',
+        {
+          type: 'category',
+          label: '🎨 Generative Models',
+          items: [
+            'applications/generative/index',
+            'applications/generative/autoencoder',
+            'applications/generative/vae',
+            'applications/generative/gan',
+            'applications/generative/diffusion',
+          ],
+        },
+        {
+          type: 'category',
+          label: '🔁 Sequence Models & Time Series',
+          items: [
+            'applications/sequence/index',
+            'applications/sequence/recurrent-networks',
+          ],
+        },
+        {
+          type: 'category',
+          label: '🔬 Graphs, Scientific & Structured',
+          items: [
+            'applications/scientific/index',
+            'applications/scientific/graph-neural-networks',
+            'applications/scientific/pinn',
+          ],
+        },
+        {
+          type: 'category',
+          label: '🧬 Multimodal & Adaptation',
+          items: [
+            'applications/adaptation/index',
+            'applications/adaptation/lora-finetuning',
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: '📈 Scale',
       items: [
         'scale/index',


### PR DESCRIPTION
Adds a new top-level **🧩 Applications** section (+ 3 methodology guides into Research) — **21 new guides**, each a small, self-contained, CPU-verified Flax NNX implementation with a matching runnable example script. **42 examples total; site builds clean (zero broken links).**

## Tier 1 (Wave 1)
- **Generative:** Autoencoder, VAE, DCGAN, Diffusion (DDPM) — `nnx.ConvTranspose`, `nnx.SpectralNorm`, `nnx.Embed`/`GroupNorm`, two-optimizer adversarial step.
- **Sequence:** Recurrent networks (RNN/LSTM/GRU/Bidirectional + manual `nnx.scan`).
- **Scientific:** GCN (0.97 node acc on Karate Club), PINN (autodiff *through the model*).
- **Adaptation:** LoRA fine-tuning (`nnx.LoRALinear`, `wrt=nnx.LoRAParam`, base provably frozen).

## Tier 2 (Wave 2)
- **Generative:** Normalizing Flows (RealNVP, exact likelihood).
- **Sequence:** Seq2seq w/ cross-attention (→100% token acc), time-series LSTM forecasting, word2vec.
- **Scientific:** Neural ODE (RK4 through `scan`), tabular DNN (categorical embeddings), Mixture-of-Experts (top-k routing).
- **Vision (new sub-category):** Vision Transformer (85% acc), U-Net segmentation.
- **Adaptation:** toy CLIP (cross-modal contrastive).
- **Research:** metric-learning (triplet), interpretability (saliency/IG/Grad-CAM), uncertainty (MC-dropout + deep ensembles via `nnx.vmap`).

## Verification
Every example passed a 5-gate CPU check (`py_compile` → import → forward-shape → N train-steps with loss decreasing / task-metric improving) on the pinned jax 0.9.2 / flax 0.12.6 / optax 0.2.8. Real metrics are embedded in each guide's Results section. Adds shared `ConvEncoder`/`ConvDecoder` + `bce_loss`/`kl_divergence`; registered in `index.py`/README; `intro.md` + Research hub updated.

> Sample-image guides (VAE/GAN/Diffusion) show real CPU training curves; higher-quality GPU-generated sample grids are a best-effort follow-up (Kaggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)